### PR TITLE
Fix to avoid async deadlock

### DIFF
--- a/src/PocketBaseClient.CodeGenerator/Generation/ItemInfo.cs
+++ b/src/PocketBaseClient.CodeGenerator/Generation/ItemInfo.cs
@@ -162,13 +162,8 @@ namespace {settings.NamespaceModels}
             => ({CollectionInfo.ClassName})DataServiceBase.GetCollection<{ClassName}>()!;
         #endregion Collection
 
-        #region GetById
-        public static {ClassName}? GetById(string id, bool reload = false) 
-            => Task.Run(async () => await GetByIdAsync(id, reload)).GetAwaiter().GetResult();
-
         public static async Task<{ClassName}?> GetByIdAsync(string id, bool reload = false)
             => await DataServiceBase.GetCollection<{ClassName}>()!.GetByIdAsync(id, reload);
-        #endregion GetById
     }}
 }}");
 

--- a/src/PocketBaseClient.CodeGenerator/Generation/ItemInfo.cs
+++ b/src/PocketBaseClient.CodeGenerator/Generation/ItemInfo.cs
@@ -164,7 +164,7 @@ namespace {settings.NamespaceModels}
 
         #region GetById
         public static {ClassName}? GetById(string id, bool reload = false) 
-            => GetByIdAsync(id, reload).Result;
+            => Task.Run(async () => await GetByIdAsync(id, reload)).GetAwaiter().GetResult();
 
         public static async Task<{ClassName}?> GetByIdAsync(string id, bool reload = false)
             => await DataServiceBase.GetCollection<{ClassName}>()!.GetByIdAsync(id, reload);

--- a/src/PocketBaseClient.CodeGenerator/Interactive/Process.cs
+++ b/src/PocketBaseClient.CodeGenerator/Interactive/Process.cs
@@ -8,9 +8,9 @@
 // pocketbase-csharp-sdk project: https://github.com/PRCV1/pocketbase-csharp-sdk 
 // pocketbase project: https://github.com/pocketbase/pocketbase
 
+using PocketBaseClient.CodeGenerator.Generation;
 using PocketBaseClient.CodeGenerator.Helpers;
 using PocketBaseClient.CodeGenerator.Models;
-using PocketBaseClient.CodeGenerator.Generation;
 using Sharprompt;
 
 namespace PocketBaseClient.CodeGenerator.Interactive
@@ -213,7 +213,9 @@ namespace PocketBaseClient.CodeGenerator.Interactive
                 pocketBaseCredentials = Prompt.Bind<PocketBaseCredentials>();
                 try
                 {
-                    schema = SchemaDownloader.DownloadSchemaAsync(pocketBaseUri, pocketBaseCredentials.Email ?? "", pocketBaseCredentials.Password ?? "").Result;
+                    schema = Task.Run(async () => await SchemaDownloader.DownloadSchemaAsync(pocketBaseUri,
+                            pocketBaseCredentials.Email ?? "", pocketBaseCredentials.Password ?? "")).GetAwaiter()
+                        .GetResult();
                 }
                 catch (Exception ex)
                 {

--- a/src/PocketBaseClient.CodeGenerator/Models/PocketBaseSchema.cs
+++ b/src/PocketBaseClient.CodeGenerator/Models/PocketBaseSchema.cs
@@ -8,8 +8,8 @@
 // pocketbase-csharp-sdk project: https://github.com/PRCV1/pocketbase-csharp-sdk 
 // pocketbase project: https://github.com/pocketbase/pocketbase
 
-using pocketbase_csharp_sdk.Models.Collection;
 using System.Text.Json;
+using pocketbase_csharp_sdk.Models.Collection;
 
 namespace PocketBaseClient.CodeGenerator.Models
 {
@@ -89,7 +89,9 @@ namespace PocketBaseClient.CodeGenerator.Models
         /// <param name="path">Path where save the schema</param>
         /// <returns></returns>
         public void SaveToFile(string path)
-            => SaveToFileAsync(path).Wait();
+        {
+            Task.Run(async () => await SaveToFileAsync(path)).GetAwaiter().GetResult();
+        }
 
         /// <summary>
         /// Loads the Schema from file

--- a/src/PocketBaseClient/Orm/CollectionBase.ItemList.cs
+++ b/src/PocketBaseClient/Orm/CollectionBase.ItemList.cs
@@ -16,9 +16,6 @@ namespace PocketBaseClient.Orm
 
 
         /// <inheritdoc />
-        public abstract bool Contains(object? element);
-
-        /// <inheritdoc />
         object? IBasicList.Add(object? element)
             => AddInternal(element);
         internal abstract object? AddInternal(object? element);
@@ -30,11 +27,11 @@ namespace PocketBaseClient.Orm
 
 
         /// <inheritdoc />
-        bool IBasicList.SaveChanges(ListSaveDiscardModes mode)
-            => SaveChanges(true);
+        async Task<bool> IBasicCollection.SaveChangesAsync(ListSaveDiscardModes mode)
+            => await SaveChangesAsync(true);
 
         /// <inheritdoc />
-        void IBasicList.DiscardChanges(ListSaveDiscardModes mode)
+        void IBasicCollection.DiscardChanges(ListSaveDiscardModes mode)
             => DiscardChanges();
 
     }

--- a/src/PocketBaseClient/Orm/CollectionBase.Repository.cs
+++ b/src/PocketBaseClient/Orm/CollectionBase.Repository.cs
@@ -31,13 +31,17 @@ namespace PocketBaseClient.Orm
 
             return result;
         }
+
         /// <summary>
         /// Save all Collection items to PocketBase, performing Create, Update or Delete for every Item to server
         /// </summary>
         /// <param name="onlyIfChanges">False to force saving unmodified items</param>
         /// <returns></returns>
         public bool SaveChanges(bool onlyIfChanges = true)
-            => SaveChangesAsync(onlyIfChanges).Result;
+        {
+            return Task.Run(async () => await SaveChangesAsync(onlyIfChanges)).GetAwaiter().GetResult();
+        }
+
         #endregion  Save
 
         #region DiscardChanges

--- a/src/PocketBaseClient/Orm/CollectionBase.Repository.cs
+++ b/src/PocketBaseClient/Orm/CollectionBase.Repository.cs
@@ -32,16 +32,6 @@ namespace PocketBaseClient.Orm
             return result;
         }
 
-        /// <summary>
-        /// Save all Collection items to PocketBase, performing Create, Update or Delete for every Item to server
-        /// </summary>
-        /// <param name="onlyIfChanges">False to force saving unmodified items</param>
-        /// <returns></returns>
-        public bool SaveChanges(bool onlyIfChanges = true)
-        {
-            return Task.Run(async () => await SaveChangesAsync(onlyIfChanges)).GetAwaiter().GetResult();
-        }
-
         #endregion  Save
 
         #region DiscardChanges

--- a/src/PocketBaseClient/Orm/CollectionBase.cs
+++ b/src/PocketBaseClient/Orm/CollectionBase.cs
@@ -17,7 +17,7 @@ namespace PocketBaseClient.Orm
     /// <summary>
     /// Base class for a Collection in PocketBase
     /// </summary>
-    public abstract partial class CollectionBase : IBasicList
+    public abstract partial class CollectionBase : IBasicCollection
     {
         /// <summary>
         /// The PocketBase 'id' of the Collection

--- a/src/PocketBaseClient/Orm/CollectionBase[T].ItemList.cs
+++ b/src/PocketBaseClient/Orm/CollectionBase[T].ItemList.cs
@@ -8,8 +8,8 @@
 // pocketbase-csharp-sdk project: https://github.com/PRCV1/pocketbase-csharp-sdk 
 // pocketbase project: https://github.com/pocketbase/pocketbase
 
-using PocketBaseClient.Orm.Structures;
 using System.Collections;
+using PocketBaseClient.Orm.Structures;
 
 namespace PocketBaseClient.Orm
 {
@@ -30,7 +30,10 @@ namespace PocketBaseClient.Orm
 
 
         /// <inheritdoc />
-        public T? GetById(string? id, bool reload = false) => GetByIdAsync(id, reload).Result;
+        public T? GetById(string? id, bool reload = false)
+        {
+            return Task.Run(async () => await GetByIdAsync(id, reload)).GetAwaiter().GetResult();
+        }
 
         /// <summary>
         /// Gets the item, with its id (async)

--- a/src/PocketBaseClient/Orm/CollectionBase[T].RemoteItemList.cs
+++ b/src/PocketBaseClient/Orm/CollectionBase[T].RemoteItemList.cs
@@ -8,8 +8,8 @@
 // pocketbase-csharp-sdk project: https://github.com/PRCV1/pocketbase-csharp-sdk 
 // pocketbase project: https://github.com/pocketbase/pocketbase
 
-using System.Collections;
 using PocketBaseClient.Orm.Structures;
+using System.Collections;
 
 namespace PocketBaseClient.Orm
 {
@@ -28,13 +28,6 @@ namespace PocketBaseClient.Orm
         public IEnumerator<T> GetEnumerator()
             => GetItems().GetEnumerator();
 
-
-        /// <inheritdoc />
-        public T? GetById(string? id, bool reload = false)
-        {
-            return Task.Run(async () => await GetByIdAsync(id, reload)).GetAwaiter().GetResult();
-        }
-
         /// <summary>
         /// Gets the item, with its id (async)
         /// </summary>
@@ -44,14 +37,6 @@ namespace PocketBaseClient.Orm
         public async Task<T?> GetByIdAsync(string? id, bool reload = false)
             => await GetByIdInternalAsync(id, reload);
 
-
-        /// <inheritdoc />
-        public override bool Contains(object? element)
-            => Contains(element as T);
-
-        /// <inheritdoc />
-        public bool Contains(T? element)
-            => GetById(element?.Id) != null;
 
         /// <inheritdoc />
         T? IBasicList<T>.Add(T? item)
@@ -69,7 +54,7 @@ namespace PocketBaseClient.Orm
         /// <inheritdoc />
         T? IBasicList<T>.Remove(T? item)
             => RemoveInternal(item) as T;
-        
+
         protected override object? RemoveInternal(object? element)
         {
             if (element is T item && Delete(item))
@@ -78,18 +63,13 @@ namespace PocketBaseClient.Orm
         }
 
         /// <inheritdoc />
-        T? IItemList<T>.Remove(string? id)
+        async Task<T?> IRemoteItemList<T>.RemoveAsync(string? id)
         {
-            var item = GetById(id);
+            var item = await GetByIdAsync(id);
             if (Delete(item))
                 return item;
             return null;
         }
-
-
-        /// <inheritdoc />
-        public bool Delete(string? id)
-            => Delete(GetById(id));
 
         /// <inheritdoc />
         public bool Delete(T? item)

--- a/src/PocketBaseClient/Orm/CollectionBase[T].Repository.cs
+++ b/src/PocketBaseClient/Orm/CollectionBase[T].Repository.cs
@@ -1,12 +1,7 @@
-﻿using pocketbase_csharp_sdk.Models;
+﻿using System.Web;
+using pocketbase_csharp_sdk.Models;
 using PocketBaseClient.Orm.Cache;
 using PocketBaseClient.Orm.Structures;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Web;
 
 namespace PocketBaseClient.Orm
 {
@@ -85,7 +80,9 @@ namespace PocketBaseClient.Orm
             int currentPage = 1;
             while (totalItems == null || loadedItems < totalItems)
             {
-                var page = GetPageFromPbAsync(pageNumber: currentPage, filter: filter, sort: sort).Result;
+                var page = Task
+                    .Run(async () => await GetPageFromPbAsync(currentPage, filter: filter, sort: sort))
+                    .GetAwaiter().GetResult();
                 if (page != null)
                 {
                     currentPage++;
@@ -170,7 +167,7 @@ namespace PocketBaseClient.Orm
                 int currentPage = 1;
                 while (_PocketBaseItemsCount == null || loadedItems < _PocketBaseItemsCount)
                 {
-                    var page = GetPageFromPbAsync(currentPage).Result;
+                    var page = Task.Run(async () => await GetPageFromPbAsync(currentPage)).GetAwaiter().GetResult();
                     if (page != null)
                     {
                         currentPage++;

--- a/src/PocketBaseClient/Orm/CollectionBase[T].cs
+++ b/src/PocketBaseClient/Orm/CollectionBase[T].cs
@@ -45,6 +45,7 @@ namespace PocketBaseClient.Orm
         #endregion DiscardChanges
 
         #region Save Item
+
         /// <summary>
         /// Save an item to PocketBase, performing a Create or Update to server
         /// </summary>
@@ -52,7 +53,9 @@ namespace PocketBaseClient.Orm
         /// <param name="onlyIfChanges">False to force saving unmodified items</param>
         /// <returns></returns>
         internal bool Save(T item, bool onlyIfChanges = true)
-            => SaveAsync(item, onlyIfChanges).Result;
+        {
+            return Task.Run(async () => await SaveAsync(item, onlyIfChanges)).GetAwaiter().GetResult();
+        }
 
         /// <summary>
         /// Save an item to PocketBase, performing a Create, Update or Delete to server (async)

--- a/src/PocketBaseClient/Orm/CollectionBase[T].cs
+++ b/src/PocketBaseClient/Orm/CollectionBase[T].cs
@@ -17,7 +17,7 @@ namespace PocketBaseClient.Orm
     /// Base class for a Collection of PocketBase, with registries mapped in the ORM
     /// </summary>
     /// <typeparam name="T">The type of the mapped registries</typeparam>
-    public abstract partial class CollectionBase<T> : CollectionBase, IItemList<T>
+    public abstract partial class CollectionBase<T> : CollectionBase, Structures.ICollection<T>
         where T : ItemBase, new()
     {
         /// <summary>
@@ -45,17 +45,6 @@ namespace PocketBaseClient.Orm
         #endregion DiscardChanges
 
         #region Save Item
-
-        /// <summary>
-        /// Save an item to PocketBase, performing a Create or Update to server
-        /// </summary>
-        /// <param name="item">The item to be saved</param>
-        /// <param name="onlyIfChanges">False to force saving unmodified items</param>
-        /// <returns></returns>
-        internal bool Save(T item, bool onlyIfChanges = true)
-        {
-            return Task.Run(async () => await SaveAsync(item, onlyIfChanges)).GetAwaiter().GetResult();
-        }
 
         /// <summary>
         /// Save an item to PocketBase, performing a Create, Update or Delete to server (async)

--- a/src/PocketBaseClient/Orm/Diagrams/ListStructures.cd
+++ b/src/PocketBaseClient/Orm/Diagrams/ListStructures.cd
@@ -1,0 +1,113 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ClassDiagram MajorVersion="1" MinorVersion="1">
+  <Class Name="PocketBaseClient.Orm.Structures.FieldBasicList&lt;T&gt;" Collapsed="true">
+    <Position X="1.75" Y="7.25" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAICAACAAAAAABAAAAAABAQAAACAAAAEEkAAAAAQAAA=</HashCode>
+      <FileName>Orm\Structures\FieldBasicList[T].cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" />
+  </Class>
+  <Class Name="PocketBaseClient.Orm.Structures.FieldItemList&lt;T&gt;" Collapsed="true">
+    <Position X="1.75" Y="8.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>EAAAAAAAAAAAAAAAAAgAAAAAAAEAAAAAAAAAAAAAIIA=</HashCode>
+      <FileName>Orm\Structures\FieldItemList[T].cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" />
+  </Class>
+  <Class Name="PocketBaseClient.Orm.CollectionBase" Collapsed="true">
+    <Position X="13.75" Y="7.25" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AQACAAgAAoAIIEIAIAAAAAQCAICAAAAEFAgAAAAQAAA=</HashCode>
+      <FileName>Orm\CollectionBase.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" />
+  </Class>
+  <Class Name="PocketBaseClient.Orm.CollectionBase&lt;T&gt;" Collapsed="true">
+    <Position X="13.75" Y="8.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>gQAAAAAwAsAIIFIIIBBEEAACCIEIAgAAhAAAAAAQKIA=</HashCode>
+      <FileName>Orm\CollectionBase[T].cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" />
+  </Class>
+  <Interface Name="PocketBaseClient.Orm.Structures.IItemList&lt;T&gt;" Collapsed="true">
+    <Position X="8" Y="4.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAkAAAAAgSAgAAAAAAAEAAgAAAAAAAAAAIIA=</HashCode>
+      <FileName>Orm\Structures\IItemList[T].cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="PocketBaseClient.Orm.Structures.IBasicList" Collapsed="true">
+    <Position X="8" Y="1" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAICAAAAQAAAAAAAAAAABAQAAAAAAAAAIAAAAIAEAAA=</HashCode>
+      <FileName>Orm\Structures\IBasicList.cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="PocketBaseClient.Orm.Structures.IBasicList&lt;T&gt;" Collapsed="true">
+    <Position X="8" Y="2.75" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAIAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAIAEAAA=</HashCode>
+      <FileName>Orm\Structures\IBasicList[T].cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="PocketBaseClient.Orm.Structures.IFieldBasicList&lt;T&gt;" Collapsed="true">
+    <Position X="3.75" Y="4.25" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAACQAAA=</HashCode>
+      <FileName>Orm\Structures\IFieldBasicList[T].cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="PocketBaseClient.Orm.Structures.IFieldItemList&lt;T&gt;" Collapsed="true">
+    <Position X="5.25" Y="7.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>Orm\Structures\IFieldItemList[T].cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="PocketBaseClient.Orm.Structures.ILimitable" Collapsed="true">
+    <Position X="1.5" Y="4" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAA=</HashCode>
+      <FileName>Orm\Structures\ILimitable.cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="PocketBaseClient.Orm.Structures.IOwnedByItem" Collapsed="true">
+    <Position X="1.5" Y="4.75" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>Orm\Structures\IOwnedByItem.cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="PocketBaseClient.Orm.Structures.IBasicCollection" Collapsed="true">
+    <Position X="11" Y="2.75" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAEAAAAAAAAAAAIAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>Orm\Structures\IBasicCollection.cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="PocketBaseClient.Orm.Structures.ICollection&lt;T&gt;" Collapsed="true">
+    <Position X="10" Y="7.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>Orm\Structures\ICollection[T].cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="PocketBaseClient.Orm.Structures.ILocalItemList&lt;T&gt;" Collapsed="true">
+    <Position X="6.75" Y="6" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>Orm\Structures\ILocalItemList[T].cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="PocketBaseClient.Orm.Structures.IRemoteItemList&lt;T&gt;" Collapsed="true">
+    <Position X="9" Y="6" Width="1.75" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>Orm\Structures\IRemoteItemList[T].cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Font Name="Segoe UI" Size="9" />
+</ClassDiagram>

--- a/src/PocketBaseClient/Orm/ItemBase.cs
+++ b/src/PocketBaseClient/Orm/ItemBase.cs
@@ -159,15 +159,6 @@ namespace PocketBaseClient.Orm
         /// </summary>
         /// <returns></returns>
         public async Task ReloadAsync() => await LoadAsync(true);
-
-        /// <summary>
-        /// Reloads the object with the data stored in PocketBase
-        /// </summary>
-        public void Reload()
-        {
-            Task.Run(async () => await ReloadAsync()).GetAwaiter().GetResult();
-        }
-
         #endregion Reload
 
         #region Delete
@@ -202,16 +193,6 @@ namespace PocketBaseClient.Orm
         #endregion DiscardChanges
 
         #region Save
-
-        /// <summary>
-        /// Saves the object to PocketBase (internally performs insert or update)
-        /// </summary>
-        /// <param name="onlyIfChanges">False to force saving the object also if is unmodified (default behaviour)</param>
-        /// <returns></returns>
-        public bool Save(bool onlyIfChanges = false)
-        {
-            return Task.Run(async () => await SaveAsync(onlyIfChanges)).GetAwaiter().GetResult();
-        }
 
         /// <summary>
         /// Saves the object to PocketBase (internally performs insert or update) (async)

--- a/src/PocketBaseClient/Orm/ItemBase.cs
+++ b/src/PocketBaseClient/Orm/ItemBase.cs
@@ -8,11 +8,11 @@
 // pocketbase-csharp-sdk project: https://github.com/PRCV1/pocketbase-csharp-sdk 
 // pocketbase project: https://github.com/pocketbase/pocketbase
 
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 using pocketbase_csharp_sdk.Json;
 using pocketbase_csharp_sdk.Models;
 using PocketBaseClient.Orm.Structures;
-using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
 
 namespace PocketBaseClient.Orm
 {
@@ -145,8 +145,12 @@ namespace PocketBaseClient.Orm
                 throw new Exception($"Object does not exists in PocketBase; Collection:{Collection.Name}; RegistryId:{Id}");
             }
         }
+
         private void Load(bool forceLoad = false)
-            => LoadAsync(forceLoad).Wait();
+        {
+            Task.Run(async () => await LoadAsync(forceLoad)).GetAwaiter().GetResult();
+        }
+
         #endregion Load
 
         #region Reload
@@ -159,7 +163,11 @@ namespace PocketBaseClient.Orm
         /// <summary>
         /// Reloads the object with the data stored in PocketBase
         /// </summary>
-        public void Reload() => ReloadAsync().Wait();
+        public void Reload()
+        {
+            Task.Run(async () => await ReloadAsync()).GetAwaiter().GetResult();
+        }
+
         #endregion Reload
 
         #region Delete
@@ -194,13 +202,16 @@ namespace PocketBaseClient.Orm
         #endregion DiscardChanges
 
         #region Save
+
         /// <summary>
         /// Saves the object to PocketBase (internally performs insert or update)
         /// </summary>
         /// <param name="onlyIfChanges">False to force saving the object also if is unmodified (default behaviour)</param>
         /// <returns></returns>
         public bool Save(bool onlyIfChanges = false)
-            => SaveAsync(onlyIfChanges).Result;
+        {
+            return Task.Run(async () => await SaveAsync(onlyIfChanges)).GetAwaiter().GetResult();
+        }
 
         /// <summary>
         /// Saves the object to PocketBase (internally performs insert or update) (async)

--- a/src/PocketBaseClient/Orm/Json/RelationListConverter.cs
+++ b/src/PocketBaseClient/Orm/Json/RelationListConverter.cs
@@ -21,7 +21,7 @@ namespace PocketBaseClient.Orm.Json
     /// <typeparam name="L">The type of the list</typeparam>
     /// <typeparam name="T">The mapped related type</typeparam>
     public class RelationListConverter<L, T> : JsonConverter<L?>
-        where L : IBasicList<T>, new()
+        where L : FieldItemList<T>, new()
         where T : ItemBase, new()
     {
         /// <inheritdoc />

--- a/src/PocketBaseClient/Orm/Structures/FieldBasicList[T].cs
+++ b/src/PocketBaseClient/Orm/Structures/FieldBasicList[T].cs
@@ -64,10 +64,6 @@ namespace PocketBaseClient.Orm.Structures
             => element != null && InnerList.Contains(element);
 
         /// <inheritdoc />
-        bool IBasicList.Contains(object? element)
-            => element is T item && Contains(item);
-
-        /// <inheritdoc />
         public T? Add(T? element)
         {
             if (MaxSize != null && Count == MaxSize)
@@ -105,18 +101,5 @@ namespace PocketBaseClient.Orm.Structures
             return element is T item ? Remove(item) : default;
         }
 
-        /// <inheritdoc />
-        public void DiscardChanges(ListSaveDiscardModes mode)
-        {
-            //IEPA!!
-            throw new NotImplementedException();
-        }
-
-        /// <inheritdoc />
-        public bool SaveChanges(ListSaveDiscardModes mode)
-        {
-            //IEPA!!
-            throw new NotImplementedException();
-        }
     }
 }

--- a/src/PocketBaseClient/Orm/Structures/FieldItemList[T].cs
+++ b/src/PocketBaseClient/Orm/Structures/FieldItemList[T].cs
@@ -37,8 +37,7 @@ namespace PocketBaseClient.Orm.Structures
             var item = InnerList.FirstOrDefault(i => i.Id == id);
             if (item == null) return null;
 
-            if (reload) item.Reload();
-
+            if (reload) item.Metadata_.SetNeedBeLoaded();
             return item;
         }
 
@@ -58,16 +57,8 @@ namespace PocketBaseClient.Orm.Structures
         }
 
         /// <inheritdoc />
-        public T? Remove(string? id)
-            => Remove(GetById(id));
-
-        /// <inheritdoc />
         public bool Delete(T? item)
             => Remove(item)?.Delete() ?? false;
-
-        /// <inheritdoc />
-        public bool Delete(string? id)
-            => Delete(GetById(id));
 
     }
 }

--- a/src/PocketBaseClient/Orm/Structures/IBasicCollection.cs
+++ b/src/PocketBaseClient/Orm/Structures/IBasicCollection.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PocketBaseClient.Orm.Structures
+{
+    public interface IBasicCollection : IBasicList
+    {
+        /// <summary>
+        /// Save Changes in the list
+        /// </summary>
+        /// <param name="mode">Says what to save</param>
+        /// <returns></returns>
+        Task<bool> SaveChangesAsync(ListSaveDiscardModes mode);
+
+        /// <summary>
+        /// Discard changes in list
+        /// </summary>
+        /// <param name="mode">Says what to discard</param>
+        void DiscardChanges(ListSaveDiscardModes mode);
+    }
+}

--- a/src/PocketBaseClient/Orm/Structures/IBasicList.cs
+++ b/src/PocketBaseClient/Orm/Structures/IBasicList.cs
@@ -28,13 +28,6 @@ namespace PocketBaseClient.Orm.Structures
         string? Id { get; }
 
         /// <summary>
-        /// Says if the element is contained in the list
-        /// </summary>
-        /// <param name="element">The element to check if is contained</param>
-        /// <returns></returns>
-        bool Contains(object? element);
-
-        /// <summary>
         /// Adds an element to the list
         /// </summary>
         /// <param name="element">The element to add</param>
@@ -75,24 +68,12 @@ namespace PocketBaseClient.Orm.Structures
         bool RemoveAll()
         {
             bool result = true;
-            foreach (var item in this)
-                result &= Remove(item) != null;
+            var enumerable = this.OfType<object?>().ToList();
+            for (var i = enumerable.Count - 1; i >= 0; i--)
+                result &= Remove(enumerable.ElementAt(i)) != null;
 
             return result;
         }
-
-        /// <summary>
-        /// Save Changes in the list
-        /// </summary>
-        /// <param name="mode">Says what to save</param>
-        /// <returns></returns>
-        bool SaveChanges(ListSaveDiscardModes mode);
-
-        /// <summary>
-        /// Discard changes in list
-        /// </summary>
-        /// <param name="mode">Says what to discard</param>
-        void DiscardChanges(ListSaveDiscardModes mode);
 
         /// <summary>
         /// Updates the List with the list by parameter

--- a/src/PocketBaseClient/Orm/Structures/IBasicList[T].cs
+++ b/src/PocketBaseClient/Orm/Structures/IBasicList[T].cs
@@ -12,13 +12,6 @@ namespace PocketBaseClient.Orm.Structures
 {
     public interface IBasicList<T> : IBasicList, IEnumerable<T>
     {
-        /// <summary>
-        /// Says if the element is contained in the list
-        /// </summary>
-        /// <param name="element">The element to check if is contained</param>
-        /// <returns></returns>
-        bool Contains(T? element);
-
 
         /// <summary>
         /// Adds an element to the list

--- a/src/PocketBaseClient/Orm/Structures/ICollection[T].cs
+++ b/src/PocketBaseClient/Orm/Structures/ICollection[T].cs
@@ -10,11 +10,10 @@
 
 namespace PocketBaseClient.Orm.Structures
 {
-
     /// <summary>
-    /// Definition for field types of Lists of Items
+    /// Definition for PocketBase Collection of Items
     /// </summary>
-    public interface IFieldItemList<T> : IFieldBasicList<T>, ILocalItemList<T>
+    public interface ICollection<T> : IBasicCollection, IRemoteItemList<T>
         where T : ItemBase, new()
     {
     }

--- a/src/PocketBaseClient/Orm/Structures/IFieldBasicList[T].cs
+++ b/src/PocketBaseClient/Orm/Structures/IFieldBasicList[T].cs
@@ -27,5 +27,12 @@ namespace PocketBaseClient.Orm.Structures
         void NotifyModificationToOwner()
             //=> Owner?.SetPropertyModified(Name);
             => Owner?.SetModified();
+
+        /// <summary>
+        /// Says if the element is contained in the list
+        /// </summary>
+        /// <param name="element">The element to check if is contained</param>
+        /// <returns></returns>
+        bool Contains(T? element);
     }
 }

--- a/src/PocketBaseClient/Orm/Structures/IItemList[T].cs
+++ b/src/PocketBaseClient/Orm/Structures/IItemList[T].cs
@@ -20,22 +20,6 @@ namespace PocketBaseClient.Orm.Structures
         where T : ItemBase, new()
     {
         /// <summary>
-        /// Gets the element of the list with specified Id
-        /// </summary>
-        /// <param name="id">The id of the element</param>
-        /// <returns>The element with Id (null if not exists in the list)</returns>
-        T? this[string id] 
-            => GetById(id);
-
-        /// <summary>
-        /// Gets the item of the list, with its id
-        /// </summary>
-        /// <param name="id">The id of the item to get</param>
-        /// <param name="reload">True if is forced to reload from PocketBase (default is false)</param>
-        /// <returns></returns>
-        T? GetById(string? id, bool reload = false);
-
-        /// <summary>
         /// Gets all items in the list
         /// </summary>
         /// <param name="reload">True: the elements must be reloaded from PocketBase</param>
@@ -56,23 +40,8 @@ namespace PocketBaseClient.Orm.Structures
         /// Adds a new item to the list
         /// </summary>
         /// <returns></returns>
-        T AddNew() 
+        public T AddNew() 
             => Add(new T())!;
-
-        /// <summary>
-        /// Says if the item is contained in the list
-        /// </summary>
-        /// <param name="id">The Id of the item to check if is contained</param>
-        /// <returns></returns>
-        bool Contains(string? id) 
-            => id != null && this[id] != null;
-
-        /// <summary>
-        /// Removes the item from the list
-        /// </summary>
-        /// <param name="id">The Id of the item to be removed</param>
-        /// <returns></returns>
-        T? Remove(string? id);
 
         /// <summary>
         /// Deletes the item contained in the list from memory and PocketBase
@@ -81,14 +50,6 @@ namespace PocketBaseClient.Orm.Structures
         /// <returns></returns>
         /// <remarks>Deleting an item removes it form the list and marks it as 'to be deleted' in PocketBase</remarks>
         bool Delete(T? item);
-
-        /// <summary>
-        /// Deletes the item contained in the list from memory and PocketBase
-        /// </summary>
-        /// <param name="id">The id of the item to be deleted</param>
-        /// <returns></returns>
-        /// <remarks>Deleting an item removes it form the list and marks it as 'to be deleted' in PocketBase</remarks>
-        bool Delete(string? id);
 
         /// <summary>
         /// Deletes all items in the list

--- a/src/PocketBaseClient/Orm/Structures/ILocalItemList[T].cs
+++ b/src/PocketBaseClient/Orm/Structures/ILocalItemList[T].cs
@@ -1,0 +1,62 @@
+﻿// Project site: https://github.com/iluvadev/PocketBaseClient-csharp
+//
+// Issues: https://github.com/iluvadev/PocketBaseClient-csharp/issues
+// License (MIT): https://github.com/iluvadev/PocketBaseClient-csharp/blob/main/LICENSE
+//
+// Copyright (c) 2022, iluvadev, and released under MIT License.
+//
+// pocketbase-csharp-sdk project: https://github.com/PRCV1/pocketbase-csharp-sdk 
+// pocketbase project: https://github.com/pocketbase/pocketbase
+
+namespace PocketBaseClient.Orm.Structures
+{
+    /// <summary>
+    /// Definition for Lists of items that resides in Local (memory)
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface ILocalItemList<T> : IItemList<T>
+         where T : ItemBase, new()
+    {
+        /// <summary>
+        /// Gets the item of the list, with its id
+        /// </summary>
+        /// <param name="id">The id of the item to get</param>
+        /// <param name="reload">True if is forced to reload from PocketBase (default is false)</param>
+        /// <returns></returns>
+        T? GetById(string? id, bool reload = false);
+
+        /// <summary>
+        /// Gets the element of the list with specified Id
+        /// </summary>
+        /// <param name="id">The id of the element</param>
+        /// <returns>The element with Id (null if not exists in the list)</returns>
+        public T? this[string id]
+            => GetById(id);
+
+        /// <summary>
+        /// Says if the item is contained in the list
+        /// </summary>
+        /// <param name="id">The Id of the item to check if is contained</param>
+        /// <returns></returns>
+        public bool Contains(string? id)
+            => id != null && GetById(id) != null;
+
+        /// <summary>
+        /// Removes the item from the list
+        /// </summary>
+        /// <param name="id">The Id of the item to be removed</param>
+        /// <returns></returns>
+        public T? Remove(string? id)
+            => Remove(GetById(id));
+
+        /// <summary>
+        /// Deletes the item contained in the list from memory and PocketBase
+        /// </summary>
+        /// <param name="id">The id of the item to be deleted</param>
+        /// <returns></returns>
+        /// <remarks>Deleting an item removes it form the list and marks it as 'to be deleted' in PocketBase</remarks>
+        public bool Delete(string? id)
+            => Delete(GetById(id));
+
+    }
+}

--- a/src/PocketBaseClient/Orm/Structures/IRemoteItemList[T].cs
+++ b/src/PocketBaseClient/Orm/Structures/IRemoteItemList[T].cs
@@ -1,0 +1,60 @@
+﻿// Project site: https://github.com/iluvadev/PocketBaseClient-csharp
+//
+// Issues: https://github.com/iluvadev/PocketBaseClient-csharp/issues
+// License (MIT): https://github.com/iluvadev/PocketBaseClient-csharp/blob/main/LICENSE
+//
+// Copyright (c) 2022, iluvadev, and released under MIT License.
+//
+// pocketbase-csharp-sdk project: https://github.com/PRCV1/pocketbase-csharp-sdk 
+// pocketbase project: https://github.com/pocketbase/pocketbase
+
+namespace PocketBaseClient.Orm.Structures
+{
+    /// <summary>
+    /// Definition for Lists of items that resides in Remote (PocketBase)
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface IRemoteItemList<T> : IItemList<T>
+         where T : ItemBase, new()
+    {
+        /// <summary>
+        /// Gets the item of the list, with its id, downloading from Pocketbase if is not cached
+        /// </summary>
+        /// <param name="id">The id of the item to get</param>
+        /// <param name="reload">True if is forced to reload from PocketBase (default is false)</param>
+        /// <returns></returns>
+        Task<T?> GetByIdAsync(string? id, bool reload = false);
+
+        /// <summary>
+        /// Says if the item is contained in the list
+        /// </summary>
+        /// <param name="id">The Id of the item to check if is contained</param>
+        /// <returns></returns>
+        public async Task<bool> ContainsAsync(string? id)
+            => id != null && await GetByIdAsync(id) != null;
+
+        /// <summary>
+        /// Says if the item is contained in the list
+        /// </summary>
+        /// <param name="id">The Id of the item to check if is contained</param>
+        /// <returns></returns>
+        public async Task<bool> ContainsAsync(T? item)
+            => await ContainsAsync(item?.Id);
+
+        /// <summary>
+        /// Removes the item from the list
+        /// </summary>
+        /// <param name="id">The Id of the item to be removed</param>
+        /// <returns></returns>
+        Task<T?> RemoveAsync(string? id);
+
+        /// <summary>
+        /// Deletes the item contained in the list from memory and PocketBase
+        /// </summary>
+        /// <param name="id">The id of the item to be deleted</param>
+        /// <returns></returns>
+        /// <remarks>Deleting an item removes it form the list and marks it as 'to be deleted' in PocketBase</remarks>
+        public async Task<bool> DeleteAsync(string? id)
+            => Delete(await GetByIdAsync(id));
+    }
+}

--- a/src/PocketBaseClient/Services/DataServiceBase.cs
+++ b/src/PocketBaseClient/Services/DataServiceBase.cs
@@ -61,16 +61,6 @@ namespace PocketBaseClient.Services
 
         #region Get Item
         /// <summary>
-        /// Gets the element with specified Id
-        /// </summary>
-        /// <typeparam name="T">The type of the element to find</typeparam>
-        /// <param name="id">The id of the element</param>
-        /// <param name="forceLoad">True for a reload the element from server</param>
-        /// <returns></returns>
-        public static T? GetById<T>(string id, bool forceLoad = false) where T : ItemBase, new()
-            => GetCollection<T>()?.GetById(id, forceLoad);
-
-        /// <summary>
         /// Gets the element with specified Id (async)
         /// </summary>
         /// <typeparam name="T">The type of the element to find</typeparam>
@@ -84,7 +74,6 @@ namespace PocketBaseClient.Services
 
             return await collection.GetByIdAsync(id, forceLoad);
         }
-
         #endregion Get Item
 
         #region DiscardChanges
@@ -111,16 +100,6 @@ namespace PocketBaseClient.Services
 
             return bRet;
         }
-
-        /// <summary>
-        /// Save all changed items to PocketBase, performing Create, Update or Delete for every Item changed to server 
-        /// </summary>
-        /// <returns></returns>
-        public bool SaveChanges()
-        {
-            return Task.Run(async () => await SaveChangesAsync()).GetAwaiter().GetResult();
-        }
-
         #endregion SaveChanges
 
     }

--- a/src/PocketBaseClient/Services/DataServiceBase.cs
+++ b/src/PocketBaseClient/Services/DataServiceBase.cs
@@ -111,12 +111,16 @@ namespace PocketBaseClient.Services
 
             return bRet;
         }
+
         /// <summary>
         /// Save all changed items to PocketBase, performing Create, Update or Delete for every Item changed to server 
         /// </summary>
         /// <returns></returns>
         public bool SaveChanges()
-            => SaveChangesAsync().Result;
+        {
+            return Task.Run(async () => await SaveChangesAsync()).GetAwaiter().GetResult();
+        }
+
         #endregion SaveChanges
 
     }

--- a/src/Test/PocketBaseClient.DemoTest/CodeGenerationSummary.txt
+++ b/src/Test/PocketBaseClient.DemoTest/CodeGenerationSummary.txt
@@ -25,8 +25,8 @@
 
 
 Code generated with:
-    PocketBaseClient CodeGenerator: pbcodegen v.0.5.0.0
-    At: 2023-01-15T19:00:44.1881537Z
+    PocketBaseClient CodeGenerator: pbcodegen v.0.5.1.0
+    At: 2023-02-04T11:58:23.7725777Z
 
 PocketBase Application: 
     Name: demo-test

--- a/src/Test/PocketBaseClient.DemoTest/Models/Author.cs
+++ b/src/Test/PocketBaseClient.DemoTest/Models/Author.cs
@@ -9,16 +9,13 @@
 // pocketbase-csharp-sdk project: https://github.com/PRCV1/pocketbase-csharp-sdk 
 // pocketbase project: https://github.com/pocketbase/pocketbase
 
-using pocketbase_csharp_sdk.Json;
+using System.ComponentModel.DataAnnotations;
+using System.Net.Mail;
+using System.Text.Json.Serialization;
 using PocketBaseClient.Orm;
 using PocketBaseClient.Orm.Attributes;
 using PocketBaseClient.Orm.Json;
-using PocketBaseClient.Orm.Validators;
 using PocketBaseClient.Services;
-using System.ComponentModel.DataAnnotations;
-using System.Net.Mail;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace PocketBaseClient.DemoTest.Models
 {
@@ -86,8 +83,11 @@ namespace PocketBaseClient.DemoTest.Models
         #endregion Collection
 
         #region GetById
-        public static Author? GetById(string id, bool reload = false) 
-            => GetByIdAsync(id, reload).Result;
+
+        public static Author? GetById(string id, bool reload = false)
+        {
+            return Task.Run(async () => await GetByIdAsync(id, reload)).GetAwaiter().GetResult();
+        }
 
         public static async Task<Author?> GetByIdAsync(string id, bool reload = false)
             => await DataServiceBase.GetCollection<Author>()!.GetByIdAsync(id, reload);

--- a/src/Test/PocketBaseClient.DemoTest/Models/Author.cs
+++ b/src/Test/PocketBaseClient.DemoTest/Models/Author.cs
@@ -9,13 +9,16 @@
 // pocketbase-csharp-sdk project: https://github.com/PRCV1/pocketbase-csharp-sdk 
 // pocketbase project: https://github.com/pocketbase/pocketbase
 
-using System.ComponentModel.DataAnnotations;
-using System.Net.Mail;
-using System.Text.Json.Serialization;
+using pocketbase_csharp_sdk.Json;
 using PocketBaseClient.Orm;
 using PocketBaseClient.Orm.Attributes;
 using PocketBaseClient.Orm.Json;
+using PocketBaseClient.Orm.Validators;
 using PocketBaseClient.Services;
+using System.ComponentModel.DataAnnotations;
+using System.Net.Mail;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace PocketBaseClient.DemoTest.Models
 {
@@ -82,15 +85,7 @@ namespace PocketBaseClient.DemoTest.Models
             => (CollectionAuthors)DataServiceBase.GetCollection<Author>()!;
         #endregion Collection
 
-        #region GetById
-
-        public static Author? GetById(string id, bool reload = false)
-        {
-            return Task.Run(async () => await GetByIdAsync(id, reload)).GetAwaiter().GetResult();
-        }
-
         public static async Task<Author?> GetByIdAsync(string id, bool reload = false)
             => await DataServiceBase.GetCollection<Author>()!.GetByIdAsync(id, reload);
-        #endregion GetById
     }
 }

--- a/src/Test/PocketBaseClient.DemoTest/Models/Category.cs
+++ b/src/Test/PocketBaseClient.DemoTest/Models/Category.cs
@@ -9,11 +9,16 @@
 // pocketbase-csharp-sdk project: https://github.com/PRCV1/pocketbase-csharp-sdk 
 // pocketbase project: https://github.com/pocketbase/pocketbase
 
-using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
+using pocketbase_csharp_sdk.Json;
 using PocketBaseClient.Orm;
 using PocketBaseClient.Orm.Attributes;
+using PocketBaseClient.Orm.Json;
+using PocketBaseClient.Orm.Validators;
 using PocketBaseClient.Services;
+using System.ComponentModel.DataAnnotations;
+using System.Net.Mail;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace PocketBaseClient.DemoTest.Models
 {
@@ -53,15 +58,7 @@ namespace PocketBaseClient.DemoTest.Models
             => (CollectionCategories)DataServiceBase.GetCollection<Category>()!;
         #endregion Collection
 
-        #region GetById
-
-        public static Category? GetById(string id, bool reload = false)
-        {
-            return Task.Run(async () => await GetByIdAsync(id, reload)).GetAwaiter().GetResult();
-        }
-
         public static async Task<Category?> GetByIdAsync(string id, bool reload = false)
             => await DataServiceBase.GetCollection<Category>()!.GetByIdAsync(id, reload);
-        #endregion GetById
     }
 }

--- a/src/Test/PocketBaseClient.DemoTest/Models/Category.cs
+++ b/src/Test/PocketBaseClient.DemoTest/Models/Category.cs
@@ -9,16 +9,11 @@
 // pocketbase-csharp-sdk project: https://github.com/PRCV1/pocketbase-csharp-sdk 
 // pocketbase project: https://github.com/pocketbase/pocketbase
 
-using pocketbase_csharp_sdk.Json;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 using PocketBaseClient.Orm;
 using PocketBaseClient.Orm.Attributes;
-using PocketBaseClient.Orm.Json;
-using PocketBaseClient.Orm.Validators;
 using PocketBaseClient.Services;
-using System.ComponentModel.DataAnnotations;
-using System.Net.Mail;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace PocketBaseClient.DemoTest.Models
 {
@@ -59,8 +54,11 @@ namespace PocketBaseClient.DemoTest.Models
         #endregion Collection
 
         #region GetById
-        public static Category? GetById(string id, bool reload = false) 
-            => GetByIdAsync(id, reload).Result;
+
+        public static Category? GetById(string id, bool reload = false)
+        {
+            return Task.Run(async () => await GetByIdAsync(id, reload)).GetAwaiter().GetResult();
+        }
 
         public static async Task<Category?> GetByIdAsync(string id, bool reload = false)
             => await DataServiceBase.GetCollection<Category>()!.GetByIdAsync(id, reload);

--- a/src/Test/PocketBaseClient.DemoTest/Models/Post.cs
+++ b/src/Test/PocketBaseClient.DemoTest/Models/Post.cs
@@ -9,16 +9,13 @@
 // pocketbase-csharp-sdk project: https://github.com/PRCV1/pocketbase-csharp-sdk 
 // pocketbase project: https://github.com/pocketbase/pocketbase
 
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 using pocketbase_csharp_sdk.Json;
 using PocketBaseClient.Orm;
 using PocketBaseClient.Orm.Attributes;
 using PocketBaseClient.Orm.Json;
-using PocketBaseClient.Orm.Validators;
 using PocketBaseClient.Services;
-using System.ComponentModel.DataAnnotations;
-using System.Net.Mail;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace PocketBaseClient.DemoTest.Models
 {
@@ -129,8 +126,11 @@ namespace PocketBaseClient.DemoTest.Models
         #endregion Collection
 
         #region GetById
-        public static Post? GetById(string id, bool reload = false) 
-            => GetByIdAsync(id, reload).Result;
+
+        public static Post? GetById(string id, bool reload = false)
+        {
+            return Task.Run(async () => await GetByIdAsync(id, reload)).GetAwaiter().GetResult();
+        }
 
         public static async Task<Post?> GetByIdAsync(string id, bool reload = false)
             => await DataServiceBase.GetCollection<Post>()!.GetByIdAsync(id, reload);

--- a/src/Test/PocketBaseClient.DemoTest/Models/Post.cs
+++ b/src/Test/PocketBaseClient.DemoTest/Models/Post.cs
@@ -9,13 +9,16 @@
 // pocketbase-csharp-sdk project: https://github.com/PRCV1/pocketbase-csharp-sdk 
 // pocketbase project: https://github.com/pocketbase/pocketbase
 
-using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
 using pocketbase_csharp_sdk.Json;
 using PocketBaseClient.Orm;
 using PocketBaseClient.Orm.Attributes;
 using PocketBaseClient.Orm.Json;
+using PocketBaseClient.Orm.Validators;
 using PocketBaseClient.Services;
+using System.ComponentModel.DataAnnotations;
+using System.Net.Mail;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace PocketBaseClient.DemoTest.Models
 {
@@ -125,15 +128,7 @@ namespace PocketBaseClient.DemoTest.Models
             => (CollectionPosts)DataServiceBase.GetCollection<Post>()!;
         #endregion Collection
 
-        #region GetById
-
-        public static Post? GetById(string id, bool reload = false)
-        {
-            return Task.Run(async () => await GetByIdAsync(id, reload)).GetAwaiter().GetResult();
-        }
-
         public static async Task<Post?> GetByIdAsync(string id, bool reload = false)
             => await DataServiceBase.GetCollection<Post>()!.GetByIdAsync(id, reload);
-        #endregion GetById
     }
 }

--- a/src/Test/PocketBaseClient.DemoTest/Models/Tag.cs
+++ b/src/Test/PocketBaseClient.DemoTest/Models/Tag.cs
@@ -9,11 +9,16 @@
 // pocketbase-csharp-sdk project: https://github.com/PRCV1/pocketbase-csharp-sdk 
 // pocketbase project: https://github.com/pocketbase/pocketbase
 
-using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
+using pocketbase_csharp_sdk.Json;
 using PocketBaseClient.Orm;
 using PocketBaseClient.Orm.Attributes;
+using PocketBaseClient.Orm.Json;
+using PocketBaseClient.Orm.Validators;
 using PocketBaseClient.Services;
+using System.ComponentModel.DataAnnotations;
+using System.Net.Mail;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace PocketBaseClient.DemoTest.Models
 {
@@ -55,14 +60,7 @@ namespace PocketBaseClient.DemoTest.Models
             => (CollectionTags)DataServiceBase.GetCollection<Tag>()!;
         #endregion Collection
 
-        #region GetById
-        public static Tag? GetById(string id, bool reload = false)
-        {
-            return Task.Run(async () => await GetByIdAsync(id, reload)).GetAwaiter().GetResult();
-        }
-
         public static async Task<Tag?> GetByIdAsync(string id, bool reload = false)
             => await DataServiceBase.GetCollection<Tag>()!.GetByIdAsync(id, reload);
-        #endregion GetById
     }
 }

--- a/src/Test/PocketBaseClient.DemoTest/Models/Tag.cs
+++ b/src/Test/PocketBaseClient.DemoTest/Models/Tag.cs
@@ -9,16 +9,11 @@
 // pocketbase-csharp-sdk project: https://github.com/PRCV1/pocketbase-csharp-sdk 
 // pocketbase project: https://github.com/pocketbase/pocketbase
 
-using pocketbase_csharp_sdk.Json;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 using PocketBaseClient.Orm;
 using PocketBaseClient.Orm.Attributes;
-using PocketBaseClient.Orm.Json;
-using PocketBaseClient.Orm.Validators;
 using PocketBaseClient.Services;
-using System.ComponentModel.DataAnnotations;
-using System.Net.Mail;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace PocketBaseClient.DemoTest.Models
 {
@@ -61,8 +56,10 @@ namespace PocketBaseClient.DemoTest.Models
         #endregion Collection
 
         #region GetById
-        public static Tag? GetById(string id, bool reload = false) 
-            => GetByIdAsync(id, reload).Result;
+        public static Tag? GetById(string id, bool reload = false)
+        {
+            return Task.Run(async () => await GetByIdAsync(id, reload)).GetAwaiter().GetResult();
+        }
 
         public static async Task<Tag?> GetByIdAsync(string id, bool reload = false)
             => await DataServiceBase.GetCollection<Tag>()!.GetByIdAsync(id, reload);

--- a/src/Test/PocketBaseClient.DemoTest/Models/TestForRelated.cs
+++ b/src/Test/PocketBaseClient.DemoTest/Models/TestForRelated.cs
@@ -9,11 +9,16 @@
 // pocketbase-csharp-sdk project: https://github.com/PRCV1/pocketbase-csharp-sdk 
 // pocketbase project: https://github.com/pocketbase/pocketbase
 
-using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
+using pocketbase_csharp_sdk.Json;
 using PocketBaseClient.Orm;
 using PocketBaseClient.Orm.Attributes;
+using PocketBaseClient.Orm.Json;
+using PocketBaseClient.Orm.Validators;
 using PocketBaseClient.Services;
+using System.ComponentModel.DataAnnotations;
+using System.Net.Mail;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace PocketBaseClient.DemoTest.Models
 {
@@ -71,15 +76,7 @@ namespace PocketBaseClient.DemoTest.Models
             => (CollectionTestForRelateds)DataServiceBase.GetCollection<TestForRelated>()!;
         #endregion Collection
 
-        #region GetById
-
-        public static TestForRelated? GetById(string id, bool reload = false)
-        {
-            return Task.Run(async () => await GetByIdAsync(id, reload)).GetAwaiter().GetResult();
-        }
-
         public static async Task<TestForRelated?> GetByIdAsync(string id, bool reload = false)
             => await DataServiceBase.GetCollection<TestForRelated>()!.GetByIdAsync(id, reload);
-        #endregion GetById
     }
 }

--- a/src/Test/PocketBaseClient.DemoTest/Models/TestForRelated.cs
+++ b/src/Test/PocketBaseClient.DemoTest/Models/TestForRelated.cs
@@ -9,16 +9,11 @@
 // pocketbase-csharp-sdk project: https://github.com/PRCV1/pocketbase-csharp-sdk 
 // pocketbase project: https://github.com/pocketbase/pocketbase
 
-using pocketbase_csharp_sdk.Json;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 using PocketBaseClient.Orm;
 using PocketBaseClient.Orm.Attributes;
-using PocketBaseClient.Orm.Json;
-using PocketBaseClient.Orm.Validators;
 using PocketBaseClient.Services;
-using System.ComponentModel.DataAnnotations;
-using System.Net.Mail;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace PocketBaseClient.DemoTest.Models
 {
@@ -77,8 +72,11 @@ namespace PocketBaseClient.DemoTest.Models
         #endregion Collection
 
         #region GetById
-        public static TestForRelated? GetById(string id, bool reload = false) 
-            => GetByIdAsync(id, reload).Result;
+
+        public static TestForRelated? GetById(string id, bool reload = false)
+        {
+            return Task.Run(async () => await GetByIdAsync(id, reload)).GetAwaiter().GetResult();
+        }
 
         public static async Task<TestForRelated?> GetByIdAsync(string id, bool reload = false)
             => await DataServiceBase.GetCollection<TestForRelated>()!.GetByIdAsync(id, reload);

--- a/src/Test/PocketBaseClient.DemoTest/Models/TestForType.cs
+++ b/src/Test/PocketBaseClient.DemoTest/Models/TestForType.cs
@@ -9,15 +9,16 @@
 // pocketbase-csharp-sdk project: https://github.com/PRCV1/pocketbase-csharp-sdk 
 // pocketbase project: https://github.com/pocketbase/pocketbase
 
-using System.ComponentModel.DataAnnotations;
-using System.Net.Mail;
-using System.Text.Json.Serialization;
 using pocketbase_csharp_sdk.Json;
 using PocketBaseClient.Orm;
 using PocketBaseClient.Orm.Attributes;
 using PocketBaseClient.Orm.Json;
 using PocketBaseClient.Orm.Validators;
 using PocketBaseClient.Services;
+using System.ComponentModel.DataAnnotations;
+using System.Net.Mail;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace PocketBaseClient.DemoTest.Models
 {
@@ -261,15 +262,7 @@ namespace PocketBaseClient.DemoTest.Models
             => (CollectionTestForTypes)DataServiceBase.GetCollection<TestForType>()!;
         #endregion Collection
 
-        #region GetById
-
-        public static TestForType? GetById(string id, bool reload = false)
-        {
-            return Task.Run(async () => await GetByIdAsync(id, reload)).GetAwaiter().GetResult();
-        }
-
         public static async Task<TestForType?> GetByIdAsync(string id, bool reload = false)
             => await DataServiceBase.GetCollection<TestForType>()!.GetByIdAsync(id, reload);
-        #endregion GetById
     }
 }

--- a/src/Test/PocketBaseClient.DemoTest/Models/TestForType.cs
+++ b/src/Test/PocketBaseClient.DemoTest/Models/TestForType.cs
@@ -9,16 +9,15 @@
 // pocketbase-csharp-sdk project: https://github.com/PRCV1/pocketbase-csharp-sdk 
 // pocketbase project: https://github.com/pocketbase/pocketbase
 
+using System.ComponentModel.DataAnnotations;
+using System.Net.Mail;
+using System.Text.Json.Serialization;
 using pocketbase_csharp_sdk.Json;
 using PocketBaseClient.Orm;
 using PocketBaseClient.Orm.Attributes;
 using PocketBaseClient.Orm.Json;
 using PocketBaseClient.Orm.Validators;
 using PocketBaseClient.Services;
-using System.ComponentModel.DataAnnotations;
-using System.Net.Mail;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace PocketBaseClient.DemoTest.Models
 {
@@ -263,8 +262,11 @@ namespace PocketBaseClient.DemoTest.Models
         #endregion Collection
 
         #region GetById
-        public static TestForType? GetById(string id, bool reload = false) 
-            => GetByIdAsync(id, reload).Result;
+
+        public static TestForType? GetById(string id, bool reload = false)
+        {
+            return Task.Run(async () => await GetByIdAsync(id, reload)).GetAwaiter().GetResult();
+        }
 
         public static async Task<TestForType?> GetByIdAsync(string id, bool reload = false)
             => await DataServiceBase.GetCollection<TestForType>()!.GetByIdAsync(id, reload);

--- a/src/Test/PocketBaseClient.DemoTest/Models/User.cs
+++ b/src/Test/PocketBaseClient.DemoTest/Models/User.cs
@@ -9,16 +9,12 @@
 // pocketbase-csharp-sdk project: https://github.com/PRCV1/pocketbase-csharp-sdk 
 // pocketbase project: https://github.com/pocketbase/pocketbase
 
-using pocketbase_csharp_sdk.Json;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 using PocketBaseClient.Orm;
 using PocketBaseClient.Orm.Attributes;
 using PocketBaseClient.Orm.Json;
-using PocketBaseClient.Orm.Validators;
 using PocketBaseClient.Services;
-using System.ComponentModel.DataAnnotations;
-using System.Net.Mail;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace PocketBaseClient.DemoTest.Models
 {
@@ -76,8 +72,11 @@ namespace PocketBaseClient.DemoTest.Models
         #endregion Collection
 
         #region GetById
-        public static User? GetById(string id, bool reload = false) 
-            => GetByIdAsync(id, reload).Result;
+
+        public static User? GetById(string id, bool reload = false)
+        {
+            return Task.Run(async () => await GetByIdAsync(id, reload)).GetAwaiter().GetResult();
+        }
 
         public static async Task<User?> GetByIdAsync(string id, bool reload = false)
             => await DataServiceBase.GetCollection<User>()!.GetByIdAsync(id, reload);

--- a/src/Test/PocketBaseClient.DemoTest/Models/User.cs
+++ b/src/Test/PocketBaseClient.DemoTest/Models/User.cs
@@ -9,12 +9,16 @@
 // pocketbase-csharp-sdk project: https://github.com/PRCV1/pocketbase-csharp-sdk 
 // pocketbase project: https://github.com/pocketbase/pocketbase
 
-using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
+using pocketbase_csharp_sdk.Json;
 using PocketBaseClient.Orm;
 using PocketBaseClient.Orm.Attributes;
 using PocketBaseClient.Orm.Json;
+using PocketBaseClient.Orm.Validators;
 using PocketBaseClient.Services;
+using System.ComponentModel.DataAnnotations;
+using System.Net.Mail;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace PocketBaseClient.DemoTest.Models
 {
@@ -71,15 +75,7 @@ namespace PocketBaseClient.DemoTest.Models
             => (CollectionUsers)DataServiceBase.GetCollection<User>()!;
         #endregion Collection
 
-        #region GetById
-
-        public static User? GetById(string id, bool reload = false)
-        {
-            return Task.Run(async () => await GetByIdAsync(id, reload)).GetAwaiter().GetResult();
-        }
-
         public static async Task<User?> GetByIdAsync(string id, bool reload = false)
             => await DataServiceBase.GetCollection<User>()!.GetByIdAsync(id, reload);
-        #endregion GetById
     }
 }

--- a/src/Test/PocketBaseClient.DemoTest/PocketBaseClient.DemoTest.csproj
+++ b/src/Test/PocketBaseClient.DemoTest/PocketBaseClient.DemoTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PocketBaseClient" Version="*" />
+    <ProjectReference Include="..\..\PocketBaseClient\PocketBaseClient.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Some part of code uses `Task.Wait()` or `Task.Result`. But these occurs deadlock when running on Desktop application or ASP.NET Web Application, which its main thread is limited to single concurrency.
To avoid that, I used `Task.Run(async () => await AsyncMethod()).GetAwaiter().GetResult()`.
`Task.Run()` will execute inner async method on other thread (threadpool by default) so that deadlock will be occured in lower chance.
`Task.GetAwaiter().GetResult()` gets the result without forgetting exceptions.
`Task.Wait()` or `Task.Result` are fire-and-forget, which forgets exceptions raised inside of async method. To re-throw the exceptions, use `Task.GetAwaiter().GetResult()`.
I tried my best to choose the best workaround to avoid deadlock. AFAIK, this is the best way to do that.
But still, there's potential risk of deadlock. (i.e. when ThreadPool hits to its concurrency limit)
So I strongly recommend to notice users about this so that users don't have to spend extra time to find out the deadlock issue.