### PR TITLE
Fix RemoveAll implementation

### DIFF
--- a/src/PocketBaseClient/Orm/Structures/IBasicList.cs
+++ b/src/PocketBaseClient/Orm/Structures/IBasicList.cs
@@ -75,9 +75,10 @@ namespace PocketBaseClient.Orm.Structures
         bool RemoveAll()
         {
             bool result = true;
-            foreach (var item in this)
-                result &= Remove(item) != null;
-
+            var enumerable = this.OfType<object?>().ToList();
+            for (var i = enumerable.Count() - 1; i >= 0; i--)
+                result &= Remove(enumerable.ElementAt(i)) != null;
+                    
             return result;
         }
 


### PR DESCRIPTION
Removing a element of enumerable in foreach is not allowed to do. It throws exception if you do that.
PR includes fixes, but I'm not sure this code is covering all. At least, it worked on my environment without any exceptions.
