### PR TITLE
Fix invalid json deserialization

### DIFF
--- a/src/PocketBaseClient.CodeGenerator/Generation/ItemInfo.cs
+++ b/src/PocketBaseClient.CodeGenerator/Generation/ItemInfo.cs
@@ -144,6 +144,31 @@ namespace {settings.NamespaceModels}
             sb.AppendLine($@"
             }}
         }}");
+            
+            sb.AppendLine($@"
+        #region Constructors
+
+        public {ClassName}() : base()
+        {{
+        }}");
+
+            sb.Append($@"
+        [JsonConstructor]
+        public {ClassName}(");
+            for (int i = 0; i < Fields.Count; i++)
+            {
+                sb.Append($@"{Fields[i].TypeName} {GetParameterNameForConstructor(Fields[i].PropertyName)}");
+                if (i < Fields.Count - 1)
+                    sb.Append($@", ");
+            }
+            sb.AppendLine($@")");
+            sb.AppendLine($@"        {{");
+            foreach (var field in Fields)
+                sb.AppendLine($@"            {field.PropertyName} = {GetParameterNameForConstructor(field.PropertyName)};");
+            sb.AppendLine($@"            AddInternal(this);");
+            sb.AppendLine($@"        }}");
+            sb.AppendLine($@"
+        #endregion");
 
             var relatedItems = Fields.SelectMany(f => f.RelatedItems);
             if (relatedItems.Any())
@@ -168,6 +193,20 @@ namespace {settings.NamespaceModels}
 }}");
 
             return new GeneratedCodeFile(fileName, sb.ToString());
+        }
+
+        /// <summary>
+        /// Generates the parameter name for JSON constructor
+        /// </summary>
+        /// <param name="propertyName">Property name of field. Assume that the first letter is upper-cased.</param>
+        /// <returns>Parameter name, which its first letter is lower-cased</returns>
+        private string GetParameterNameForConstructor(string propertyName)
+        {
+            if (string.IsNullOrEmpty(propertyName))
+                throw new InvalidOperationException("Property name cannot be null or empty");
+            if (!char.IsUpper(propertyName[0]))
+                throw new InvalidOperationException("Property name must start with upper case letter");
+            return $"{propertyName[0].ToString().ToLower()}{propertyName.Substring(1)}";
         }
 
         /// <summary>

--- a/src/PocketBaseClient.CodeGenerator/Generation/ItemInfo.cs
+++ b/src/PocketBaseClient.CodeGenerator/Generation/ItemInfo.cs
@@ -135,6 +135,9 @@ namespace {settings.NamespaceModels}
         /// <inheritdoc />
         public override void UpdateWith(ItemBase itemBase)
         {{
+            // Do not Update with this instance
+            if (ReferenceEquals(this, itemBase)) return;
+
             base.UpdateWith(itemBase);
 
             if (itemBase is {ClassName} item)
@@ -154,20 +157,16 @@ namespace {settings.NamespaceModels}
 
             sb.Append($@"
         [JsonConstructor]
-        public {ClassName}(");
+        public {ClassName}(string? id, DateTime? created, DateTime? updated");
             for (int i = 0; i < Fields.Count; i++)
-            {
-                sb.Append($@"{Fields[i].TypeName} {GetParameterNameForConstructor(Fields[i].PropertyName)}");
-                if (i < Fields.Count - 1)
-                    sb.Append($@", ");
-            }
-            sb.AppendLine($@")");
-            sb.AppendLine($@"        {{");
+                sb.Append($@", {Fields[i].TypeName} {GetParameterNameForConstructor(Fields[i])}");
+            sb.AppendLine($@")
+            : base(id, created, updated)
+        {{");
             foreach (var field in Fields)
-                sb.AppendLine($@"            {field.PropertyName} = {GetParameterNameForConstructor(field.PropertyName)};");
-            sb.AppendLine($@"            AddInternal(this);");
-            sb.AppendLine($@"        }}");
+                sb.AppendLine($@"            {field.PropertyName} = {GetParameterNameForConstructor(field)};");
             sb.AppendLine($@"
+        }}
         #endregion");
 
             var relatedItems = Fields.SelectMany(f => f.RelatedItems);
@@ -200,13 +199,14 @@ namespace {settings.NamespaceModels}
         /// </summary>
         /// <param name="propertyName">Property name of field. Assume that the first letter is upper-cased.</param>
         /// <returns>Parameter name, which its first letter is lower-cased</returns>
-        private string GetParameterNameForConstructor(string propertyName)
+        private string GetParameterNameForConstructor(FieldInfo fieldInfo)
         {
-            if (string.IsNullOrEmpty(propertyName))
-                throw new InvalidOperationException("Property name cannot be null or empty");
-            if (!char.IsUpper(propertyName[0]))
-                throw new InvalidOperationException("Property name must start with upper case letter");
-            return $"{propertyName[0].ToString().ToLower()}{propertyName.Substring(1)}";
+            return $"@{fieldInfo.PropertyName.ToCamelCase()}";
+            //if (string.IsNullOrEmpty(propertyName))
+            //    throw new InvalidOperationException("Property name cannot be null or empty");
+            //if (!char.IsUpper(propertyName[0]))
+            //    throw new InvalidOperationException("Property name must start with upper case letter");
+            //return $"{propertyName[0].ToString().ToLower()}{propertyName.Substring(1)}";
         }
 
         /// <summary>

--- a/src/PocketBaseClient.sln
+++ b/src/PocketBaseClient.sln
@@ -11,7 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Test", "Test", "{0D4E72E6-4
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PocketBaseClient.DemoTest", "Test\PocketBaseClient.DemoTest\PocketBaseClient.DemoTest.csproj", "{D112C5A5-38CD-4FFB-9674-65FA61C07C10}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PocketBaseClient.Test", "Test\PocketBaseClient.Test\PocketBaseClient.Test.csproj", "{AD01E4F3-7FE6-4B89-937E-2413EADF302E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PocketBaseClient.Test", "Test\PocketBaseClient.Test\PocketBaseClient.Test.csproj", "{AD01E4F3-7FE6-4B89-937E-2413EADF302E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/PocketBaseClient/Orm/CollectionBase[T].Repository.cs
+++ b/src/PocketBaseClient/Orm/CollectionBase[T].Repository.cs
@@ -130,7 +130,9 @@ namespace PocketBaseClient.Orm
 
         private IEnumerable<T> GetItemsInternal(bool reload = false, GetItemsFilter include = GetItemsFilter.Load | GetItemsFilter.New)
         {
-            //No marcar com a necessita recarregar si té canvis locals! O gestionar-ho bé!!
+            //TODO: Need a review
+            // If an Item has local changes? Changes will be lost? 
+            // Force Reload all cached items? Also items not yielded?
 
             var allCachedItems = Cache.AllItems.ToList();
 

--- a/src/PocketBaseClient/Orm/ItemBase.cs
+++ b/src/PocketBaseClient/Orm/ItemBase.cs
@@ -240,6 +240,16 @@ namespace PocketBaseClient.Orm
             Collection.AddInternal(this);
         }
 
+        [JsonConstructor]
+        public ItemBase(string? id, DateTime? created, DateTime? updated)
+        {
+            _Id = id;
+            Created = created;
+            Updated = updated;
+        }
+
+        protected object? AddInternal(object? element) => Collection.AddInternal(element);
+
         /// <inheritdoc />
         public override string ToString()
         {

--- a/src/PocketBaseClient/Orm/Json/EmailConverter.cs
+++ b/src/PocketBaseClient/Orm/Json/EmailConverter.cs
@@ -23,8 +23,9 @@ namespace PocketBaseClient.Orm.Json
         public override MailAddress? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             var value = reader.GetString();
-            if (value == null)
+            if (string.IsNullOrEmpty(value))
                 return null;
+
             return new MailAddress(value);
         }
 

--- a/src/PocketBaseClient/Orm/Json/EnumConverter.cs
+++ b/src/PocketBaseClient/Orm/Json/EnumConverter.cs
@@ -23,9 +23,15 @@ namespace PocketBaseClient.Orm.Json
         public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             var value = reader.GetString();
-            var valuesDesc = typeof(T).GetEnumValuesWithDescription<T>();
+            if(string.IsNullOrEmpty(value)) 
+                return null;
 
-            return valuesDesc?.FirstOrDefault(kvp => kvp.Value == value).Key;
+            var valuesDesc = typeof(T).GetEnumValuesWithDescription<T>();
+            var kvp = valuesDesc?.FirstOrDefault(kvp => kvp.Value == value);
+            if (kvp == null)
+                return null;
+
+            return kvp.Value.Key;
         }
 
         /// <inheritdoc />

--- a/src/PocketBaseClient/Orm/Json/RelationConverter.cs
+++ b/src/PocketBaseClient/Orm/Json/RelationConverter.cs
@@ -25,8 +25,9 @@ namespace PocketBaseClient.Orm.Json
         public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             var value = reader.GetString();
-            if (value == null)
+            if (string.IsNullOrEmpty(value))
                 return null;
+
             return DataServiceBase.GetCollection<T>()!.AddIdFromPb(value);
         }
 

--- a/src/PocketBaseClient/Orm/Json/UrlConverter.cs
+++ b/src/PocketBaseClient/Orm/Json/UrlConverter.cs
@@ -22,8 +22,9 @@ namespace PocketBaseClient.Orm.Json
         public override Uri? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             var value = reader.GetString();
-            if (value == null)
+            if (string.IsNullOrEmpty(value))
                 return null;
+
             return new Uri(value);
         }
 

--- a/src/PocketBaseClient/Orm/Structures/IBasicList.cs
+++ b/src/PocketBaseClient/Orm/Structures/IBasicList.cs
@@ -80,6 +80,7 @@ namespace PocketBaseClient.Orm.Structures
         /// <param name="listWithUpdates"></param>
         void UpdateWith(IBasicList listWithUpdates)
         {
+            // Do not Update with this instance
             if (!ReferenceEquals(this, listWithUpdates))
             {
                 RemoveAll();

--- a/src/PocketBaseClient/Orm/Structures/IBasicList.cs
+++ b/src/PocketBaseClient/Orm/Structures/IBasicList.cs
@@ -80,9 +80,12 @@ namespace PocketBaseClient.Orm.Structures
         /// <param name="listWithUpdates"></param>
         void UpdateWith(IBasicList listWithUpdates)
         {
-            RemoveAll();
-            foreach (var element in listWithUpdates)
-                Add(element);
+            if (!ReferenceEquals(this, listWithUpdates))
+            {
+                RemoveAll();
+                foreach (var element in listWithUpdates)
+                    Add(element);
+            }
         }
 
     }

--- a/src/PocketBaseClient/PocketBaseClient.csproj
+++ b/src/PocketBaseClient/PocketBaseClient.csproj
@@ -28,8 +28,9 @@
     <DebugType>embedded</DebugType>
   </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="pocketbase-csharp-sdk" Version="1.1.0-prerelease" />
-	</ItemGroup>
+  <ItemGroup>
+    <!--<ProjectReference Include="..\..\..\pocketbase-csharp-sdk\pocketbase-csharp-sdk\pocketbase-csharp-sdk.csproj" />-->
+	<PackageReference Include="pocketbase-csharp-sdk" Version="1.1.0-prerelease" />
+  </ItemGroup>
 
 </Project>

--- a/src/Test/PocketBaseClient.DemoTest/CodeGenerationSummary.txt
+++ b/src/Test/PocketBaseClient.DemoTest/CodeGenerationSummary.txt
@@ -26,7 +26,7 @@
 
 Code generated with:
     PocketBaseClient CodeGenerator: pbcodegen v.0.5.1.0
-    At: 2023-02-04T11:58:23.7725777Z
+    At: 2023-02-05T13:27:40.3698382Z
 
 PocketBase Application: 
     Name: demo-test

--- a/src/Test/PocketBaseClient.DemoTest/Models/Author.cs
+++ b/src/Test/PocketBaseClient.DemoTest/Models/Author.cs
@@ -68,6 +68,9 @@ namespace PocketBaseClient.DemoTest.Models
         /// <inheritdoc />
         public override void UpdateWith(ItemBase itemBase)
         {
+            // Do not Update with this instance
+            if (ReferenceEquals(this, itemBase)) return;
+
             base.UpdateWith(itemBase);
 
             if (itemBase is Author item)
@@ -79,6 +82,24 @@ namespace PocketBaseClient.DemoTest.Models
 
             }
         }
+
+        #region Constructors
+
+        public Author() : base()
+        {
+        }
+
+        [JsonConstructor]
+        public Author(string? id, DateTime? created, DateTime? updated, string? @name, MailAddress? @email, Uri? @url, string? @profile)
+            : base(id, created, updated)
+        {
+            Name = @name;
+            Email = @email;
+            Url = @url;
+            Profile = @profile;
+
+        }
+        #endregion
 
         #region Collection
         public static CollectionAuthors GetCollection() 

--- a/src/Test/PocketBaseClient.DemoTest/Models/Category.cs
+++ b/src/Test/PocketBaseClient.DemoTest/Models/Category.cs
@@ -44,6 +44,9 @@ namespace PocketBaseClient.DemoTest.Models
         /// <inheritdoc />
         public override void UpdateWith(ItemBase itemBase)
         {
+            // Do not Update with this instance
+            if (ReferenceEquals(this, itemBase)) return;
+
             base.UpdateWith(itemBase);
 
             if (itemBase is Category item)
@@ -52,6 +55,21 @@ namespace PocketBaseClient.DemoTest.Models
 
             }
         }
+
+        #region Constructors
+
+        public Category() : base()
+        {
+        }
+
+        [JsonConstructor]
+        public Category(string? id, DateTime? created, DateTime? updated, string? @name)
+            : base(id, created, updated)
+        {
+            Name = @name;
+
+        }
+        #endregion
 
         #region Collection
         public static CollectionCategories GetCollection() 

--- a/src/Test/PocketBaseClient.DemoTest/Models/Post.cs
+++ b/src/Test/PocketBaseClient.DemoTest/Models/Post.cs
@@ -103,6 +103,9 @@ namespace PocketBaseClient.DemoTest.Models
         /// <inheritdoc />
         public override void UpdateWith(ItemBase itemBase)
         {
+            // Do not Update with this instance
+            if (ReferenceEquals(this, itemBase)) return;
+
             base.UpdateWith(itemBase);
 
             if (itemBase is Post item)
@@ -118,6 +121,28 @@ namespace PocketBaseClient.DemoTest.Models
 
             }
         }
+
+        #region Constructors
+
+        public Post() : base()
+        {
+        }
+
+        [JsonConstructor]
+        public Post(string? id, DateTime? created, DateTime? updated, string? @title, Author? @author, string? @summary, string? @content, DateTime? @published, StatusEnum? @status, CategoriesList @categories, TagsList @tags)
+            : base(id, created, updated)
+        {
+            Title = @title;
+            Author = @author;
+            Summary = @summary;
+            Content = @content;
+            Published = @published;
+            Status = @status;
+            Categories = @categories;
+            Tags = @tags;
+
+        }
+        #endregion
 
         /// <inheritdoc />
         protected override IEnumerable<ItemBase?> RelatedItems 

--- a/src/Test/PocketBaseClient.DemoTest/Models/Tag.cs
+++ b/src/Test/PocketBaseClient.DemoTest/Models/Tag.cs
@@ -46,6 +46,9 @@ namespace PocketBaseClient.DemoTest.Models
         /// <inheritdoc />
         public override void UpdateWith(ItemBase itemBase)
         {
+            // Do not Update with this instance
+            if (ReferenceEquals(this, itemBase)) return;
+
             base.UpdateWith(itemBase);
 
             if (itemBase is Tag item)
@@ -54,6 +57,21 @@ namespace PocketBaseClient.DemoTest.Models
 
             }
         }
+
+        #region Constructors
+
+        public Tag() : base()
+        {
+        }
+
+        [JsonConstructor]
+        public Tag(string? id, DateTime? created, DateTime? updated, string? @name)
+            : base(id, created, updated)
+        {
+            Name = @name;
+
+        }
+        #endregion
 
         #region Collection
         public static CollectionTags GetCollection() 

--- a/src/Test/PocketBaseClient.DemoTest/Models/TestForRelated.cs
+++ b/src/Test/PocketBaseClient.DemoTest/Models/TestForRelated.cs
@@ -60,6 +60,9 @@ namespace PocketBaseClient.DemoTest.Models
         /// <inheritdoc />
         public override void UpdateWith(ItemBase itemBase)
         {
+            // Do not Update with this instance
+            if (ReferenceEquals(this, itemBase)) return;
+
             base.UpdateWith(itemBase);
 
             if (itemBase is TestForRelated item)
@@ -70,6 +73,23 @@ namespace PocketBaseClient.DemoTest.Models
 
             }
         }
+
+        #region Constructors
+
+        public TestForRelated() : base()
+        {
+        }
+
+        [JsonConstructor]
+        public TestForRelated(string? id, DateTime? created, DateTime? updated, float? @numberUnique, float? @numberNonempty, float? @numberNonemptyUnique)
+            : base(id, created, updated)
+        {
+            NumberUnique = @numberUnique;
+            NumberNonempty = @numberNonempty;
+            NumberNonemptyUnique = @numberNonemptyUnique;
+
+        }
+        #endregion
 
         #region Collection
         public static CollectionTestForRelateds GetCollection() 

--- a/src/Test/PocketBaseClient.DemoTest/Models/TestForType.cs
+++ b/src/Test/PocketBaseClient.DemoTest/Models/TestForType.cs
@@ -222,6 +222,9 @@ namespace PocketBaseClient.DemoTest.Models
         /// <inheritdoc />
         public override void UpdateWith(ItemBase itemBase)
         {
+            // Do not Update with this instance
+            if (ReferenceEquals(this, itemBase)) return;
+
             base.UpdateWith(itemBase);
 
             if (itemBase is TestForType item)
@@ -252,6 +255,43 @@ namespace PocketBaseClient.DemoTest.Models
 
             }
         }
+
+        #region Constructors
+
+        public TestForType() : base()
+        {
+        }
+
+        [JsonConstructor]
+        public TestForType(string? id, DateTime? created, DateTime? updated, string? @textNoRestrictions, string? @textRestrictions, float? @numberNoRestrictions, float? @numberRestrictions, bool? @bool, MailAddress? @emailNoRestrictions, MailAddress? @emailRestrictionsExcept, MailAddress? @emailRestrictionsOnly, Uri? @urlNoRestrictions, Uri? @urlRestrictionsExcept, Uri? @urlRestrictionsOnly, DateTime? @datetimeNoRestrictions, DateTime? @datetimeRestrictions, SelectSingleEnum? @selectSingle, SelectMultipleList @selectMultiple, dynamic? @json, object? @fileSingleNoRestriction, object? @fileSingleRestriction, object? @fileMultipleNoRestrictions, object? @fileMultipleRestrictions, TestForRelated? @reationSingle, RelationMultipleNoLimitList @relationMultipleNoLimit, RelationMultipleLimitList @relationMultipleLimit)
+            : base(id, created, updated)
+        {
+            TextNoRestrictions = @textNoRestrictions;
+            TextRestrictions = @textRestrictions;
+            NumberNoRestrictions = @numberNoRestrictions;
+            NumberRestrictions = @numberRestrictions;
+            Bool = @bool;
+            EmailNoRestrictions = @emailNoRestrictions;
+            EmailRestrictionsExcept = @emailRestrictionsExcept;
+            EmailRestrictionsOnly = @emailRestrictionsOnly;
+            UrlNoRestrictions = @urlNoRestrictions;
+            UrlRestrictionsExcept = @urlRestrictionsExcept;
+            UrlRestrictionsOnly = @urlRestrictionsOnly;
+            DatetimeNoRestrictions = @datetimeNoRestrictions;
+            DatetimeRestrictions = @datetimeRestrictions;
+            SelectSingle = @selectSingle;
+            SelectMultiple = @selectMultiple;
+            Json = @json;
+            FileSingleNoRestriction = @fileSingleNoRestriction;
+            FileSingleRestriction = @fileSingleRestriction;
+            FileMultipleNoRestrictions = @fileMultipleNoRestrictions;
+            FileMultipleRestrictions = @fileMultipleRestrictions;
+            ReationSingle = @reationSingle;
+            RelationMultipleNoLimit = @relationMultipleNoLimit;
+            RelationMultipleLimit = @relationMultipleLimit;
+
+        }
+        #endregion
 
         /// <inheritdoc />
         protected override IEnumerable<ItemBase?> RelatedItems 

--- a/src/Test/PocketBaseClient.DemoTest/Models/User.cs
+++ b/src/Test/PocketBaseClient.DemoTest/Models/User.cs
@@ -59,6 +59,9 @@ namespace PocketBaseClient.DemoTest.Models
         /// <inheritdoc />
         public override void UpdateWith(ItemBase itemBase)
         {
+            // Do not Update with this instance
+            if (ReferenceEquals(this, itemBase)) return;
+
             base.UpdateWith(itemBase);
 
             if (itemBase is User item)
@@ -69,6 +72,23 @@ namespace PocketBaseClient.DemoTest.Models
 
             }
         }
+
+        #region Constructors
+
+        public User() : base()
+        {
+        }
+
+        [JsonConstructor]
+        public User(string? id, DateTime? created, DateTime? updated, string? @name, object? @avatar, Uri? @url)
+            : base(id, created, updated)
+        {
+            Name = @name;
+            Avatar = @avatar;
+            Url = @url;
+
+        }
+        #endregion
 
         #region Collection
         public static CollectionUsers GetCollection() 

--- a/src/Test/PocketBaseClient.Test/UnitTest1.cs
+++ b/src/Test/PocketBaseClient.Test/UnitTest1.cs
@@ -28,12 +28,16 @@ namespace PocketBaseClient.Test
             //foreach(var t in myApp.Data.TestForTypesCollection.Filter(a => a.Bool.IsTrue().And(a.EmailNoRestrictions.StartsWith("pepe"))))
 
             var col = myApp.Data.TestForTypesCollection;
-            var res1 = col.Filter(i => i.Id.EndsWith("a").And(i.TextNoRestrictions.StartsWith("b")).And(i.Bool.IsTrue().And(i.SelectSingle.Equal(DemoTest.Models.TestForType.SelectSingleEnum.Option1))));
-            var res2 = col.Where(i => i.Id.EndsWith("a") && i.TextNoRestrictions.StartsWith("b"));
-            var res3 = col.Filter(i => i.ReationSingle.Equal(new DemoTest.Models.TestForRelated()));
-            res3 = col.Filter(i => i.RelationMultipleLimit.Contains(new DemoTest.Models.TestForRelated()));
+
+            //var element = col.GetByIdAsync("kabksx32qx1qhd5").Result;
+
+            //var res1 = col.Filter(i => i.Id.EndsWith("a").And(i.TextNoRestrictions.StartsWith("b")).And(i.Bool.IsTrue().And(i.SelectSingle.Equal(DemoTest.Models.TestForType.SelectSingleEnum.Option1))));
+            //var res2 = col.Where(i => i.Id.EndsWith("a") && i.TextNoRestrictions.StartsWith("b"));
+            //var res3 = col.Filter(i => i.ReationSingle.Equal(new DemoTest.Models.TestForRelated()));
+            //res3 = col.Filter(i => i.RelationMultipleLimit.Contains(new DemoTest.Models.TestForRelated()));
          
-            res3 = col.Filter(i => i.SelectMultiple.Contains(DemoTest.Models.TestForType.SelectMultipleEnum.Option1));
+            //res3 = col.Filter(i => i.SelectMultiple.Contains(DemoTest.Models.TestForType.SelectMultipleEnum.Option1));
+            
             //col.Filter(i => i.TextNoRestrictions.StartsWith("pepe")).SortById(asc).SortBySelectMultipleEnum(desc);
             //col.Filter(i => i.TextNoRestrictions.StartsWith("pepe")).SortBy(i => i.SelectMultiple);
             //res3.SortBy(i => i.SelectMultiple(Desc));


### PR DESCRIPTION
# About the issue

It's a bit difficult to explain in text. So I made a minimal setup of reproduction and explain what happens behind the code step by step.

<details>
<summary>Schema of collection</summary>

```JSON
[
    {
        "id": "and4p1eq95kv695",
        "name": "test1",
        "type": "base",
        "system": false,
        "schema": [
            {
                "id": "txkcgoew",
                "name": "field",
                "type": "relation",
                "system": false,
                "required": true,
                "unique": false,
                "options": {
                    "collectionId": "2lh048rn4ur83kl",
                    "cascadeDelete": false,
                    "maxSelect": 1,
                    "displayFields": []
                }
            }
        ],
        "listRule": "",
        "viewRule": "",
        "createRule": null,
        "updateRule": null,
        "deleteRule": null,
        "options": {}
    },
    {
        "id": "2lh048rn4ur83kl",
        "name": "test2",
        "type": "base",
        "system": false,
        "schema": [
            {
                "id": "p3974g5d",
                "name": "h",
                "type": "text",
                "system": false,
                "required": true,
                "unique": false,
                "options": {
                    "min": null,
                    "max": null,
                    "pattern": ""
                }
            },
            {
                "id": "fuqk8cf5",
                "name": "j",
                "type": "text",
                "system": false,
                "required": true,
                "unique": false,
                "options": {
                    "min": null,
                    "max": null,
                    "pattern": ""
                }
            }
        ],
        "listRule": "",
        "viewRule": "",
        "createRule": null,
        "updateRule": null,
        "deleteRule": null,
        "options": {}
    }
]
```

</details>

<details>
<summary>Records of Test1 collection</summary>

```JSON
{
  "page": 1,
  "perPage": 30,
  "totalItems": 3,
  "totalPages": 1,
  "items": [
    {
      "collectionId": "and4p1eq95kv695",
      "collectionName": "test1",
      "created": "2023-02-04 03:50:15.738Z",
      "field": "h4rvxzuxuf4wom0",
      "id": "c4qh01f9t23cws4",
      "updated": "2023-02-04 09:14:32.097Z"
    },
    {
      "collectionId": "and4p1eq95kv695",
      "collectionName": "test1",
      "created": "2023-02-04 03:50:40.302Z",
      "field": "ugoizglgmoyw2ef",
      "id": "uevwfoyey6lpr5b",
      "updated": "2023-02-04 09:14:28.275Z"
    },
    {
      "collectionId": "and4p1eq95kv695",
      "collectionName": "test1",
      "created": "2023-02-04 03:50:46.153Z",
      "field": "96wi435icppx2rb",
      "id": "bdgpqv3iwvz3ke4",
      "updated": "2023-02-04 09:14:23.897Z"
    }
  ]
}
```

</details>

<details>
<summary>Records of Test2 collection</summary>

```JSON
{
  "page": 1,
  "perPage": 30,
  "totalItems": 3,
  "totalPages": 1,
  "items": [
    {
      "collectionId": "2lh048rn4ur83kl",
      "collectionName": "test2",
      "created": "2023-02-04 03:49:52.427Z",
      "h": "1",
      "id": "h4rvxzuxuf4wom0",
      "j": "1",
      "updated": "2023-02-04 11:47:28.201Z"
    },
    {
      "collectionId": "2lh048rn4ur83kl",
      "collectionName": "test2",
      "created": "2023-02-04 03:49:56.010Z",
      "h": "2",
      "id": "ugoizglgmoyw2ef",
      "j": "2",
      "updated": "2023-02-04 11:47:25.211Z"
    },
    {
      "collectionId": "2lh048rn4ur83kl",
      "collectionName": "test2",
      "created": "2023-02-04 03:49:58.341Z",
      "h": "3",
      "id": "96wi435icppx2rb",
      "j": "3",
      "updated": "2023-02-04 11:47:22.547Z"
    }
  ]
}
```

</details>

<details>
<summary>Reproduction code</summary>

```C#
internal class Program
{
    private static void Main(string[] args)
    {
        var pbClient = new AcmeApplication();
        NotWorkingProperly(pbClient);
    }

    // Expected output and actual output is the same as follows
    //
    // H    J
    // 1    1
    // 2    2
    // 3    3
    private static void WorkingProperly(AcmeApplication pbClient)
    {
        var cnt = pbClient.Data.Test2Collection.Count();
        var idx = 0;
        Console.WriteLine("H\tJ");
        pbClient.Data.Test2Collection.FirstOrDefault(x =>
        {
            Console.WriteLine($"{x.H}\t{x.J}");
            return ++idx == cnt;
        });
    }

    // Expected output is
    //
    // H    J
    // 1    1
    // 2    2
    // 3    3
    //
    // H    J
    // 1    1
    // 2    2
    // 3    3
    //
    // Actual output is
    //
    // H    J
    // 1    1
    // 2    2
    // 3    3
    //
    // H    J
    // 1    
    // 2    
    // 3    
    private static void NotWorkingProperly(AcmeApplication pbClient)
    {
        Console.WriteLine("H\tJ");
        foreach (var test1 in pbClient.Data.Test1Collection)
        {
            var test2 = test1.Field;
            Console.WriteLine($"{test2?.H}\t{test2?.J}");
        }

        Console.Write("\n");

        WorkingProperly(pbClient);
    }
}
```

</details>

Expected outputs and actual outputs are written in `Reproduction code`.

PocketBaseClient retrieves records of a collection without expanding relation fields. So it creates pseudo objects, which only contains id in it.
In this example, `Test1` collection has a relation field of `Test2` collection (single records, not multipe records) named `Field`.
`NotWorkingProperly` method in `Reproduction code` retrieves records of Test1 collection at first. At that time, it does contain a list of pseudo objects in `Field` property, but does not contain a value of `H` and `J` property in each pseudo objects of `Field` property. So inside of the foreach statement, a value of `H` and `J` property are retrieved at the time of these properties being accessed by getter of it.
Getter of ItemBase calls `FillFromPbAsync` at the end.

https://github.com/iluvadev/PocketBaseClient/blob/a7a37faf6e333d612d8894458541e4b162fac869/src/PocketBaseClient/Orm/CollectionBase%5BT%5D.Repository.cs#L110-L121

It updates items correctly, but it does not update `_PocketBaseItemsCount` property of `CollectionBase<T>` class.

Let's go back to `Reproduction code`. After that, It calls `WorkingProperly` method.
`WorkingProperly` method accesses `H` and `J` property from this time, `FirstOrDefault`.
At the time of calling `FirstOrDefault`, Test2Collection calls `GetItems` to get enumerator, and it calls `GetItemsInternal` to retrieves records at the end.

https://github.com/iluvadev/PocketBaseClient/blob/a7a37faf6e333d612d8894458541e4b162fac869/src/PocketBaseClient/Orm/CollectionBase%5BT%5D.Repository.cs#L134-L201

At this time, if statement of line 141 is false since _PocketBaseItemsCount is still null as I said earlier.
So it goes to line 173 and calls `GetPageFromPbAsync`.
After that, records are not manually added to its collection. It's by design and it seems to be automatically added by internal setter of `id` property.

https://github.com/iluvadev/PocketBaseClient/blob/a7a37faf6e333d612d8894458541e4b162fac869/src/PocketBaseClient/Orm/ItemBase.cs#L26-L36

`Collection.ChangeIdInCache` calls `UpdateWith` at the end. `UpdateWith` of `Test2` class, which is generated by pbcodegen is as follows.

```C#
        public override void UpdateWith(ItemBase itemBase)
        {
            base.UpdateWith(itemBase);

            if (itemBase is Test2 item)
            {
                H = item.H;
                J = item.J;
            }
        }
```

As you can see, it does not update the reference of records, but it does overwrite each properties of current records in the collection.
But at this time, `item.H` has its value, but `item.J` does not have its value.
It's because `J` property is deserialized after `id` property. Let me explain more.

Response of PocketBase API is as follows.
```JSON
{
  "page": 1,
  "perPage": 30,
  "totalItems": 3,
  "totalPages": 1,
  "items": [
    {
      "collectionId": "2lh048rn4ur83kl",
      "collectionName": "test2",
      "created": "2023-02-04 03:49:52.427Z",
      "h": "1",
      "id": "h4rvxzuxuf4wom0",
      "j": "1",
      "updated": "2023-02-04 11:47:28.201Z"
    },
    {
      "collectionId": "2lh048rn4ur83kl",
      "collectionName": "test2",
      "created": "2023-02-04 03:49:56.010Z",
      "h": "2",
      "id": "ugoizglgmoyw2ef",
      "j": "2",
      "updated": "2023-02-04 11:47:25.211Z"
    },
    {
      "collectionId": "2lh048rn4ur83kl",
      "collectionName": "test2",
      "created": "2023-02-04 03:49:58.341Z",
      "h": "3",
      "id": "96wi435icppx2rb",
      "j": "3",
      "updated": "2023-02-04 11:47:22.547Z"
    }
  ]
}
```
As you can see, each properties are lexical ordered. (`collectionId` -> `collectionName` -> `created` -> `h` -> `id` -> `j` -> `updated`)
`System.Text.Json`'s deserializer goes through the response from top to bottom. So that `J` property is deserialized right after `Id` property is being deserialized.
Due to this, `item.H` has its value, but `item.J` does not have its value at the time of `UpdateWith` being called.

This is the entire picture of the issue.
I'm so sorry for long explation and I couldn't explain it well. Feel free to ask me if you don't understand.

# How I fixed it

The cause of the issue is that collection updates is called at the time of `Id` being deserialized, not all of the properties being deserialized.
So I added constructor for each items by using `[JsonConstructor]` to make sure that `UpdateWith` is being called after all properties being set.
And also, I added a reference equality check in `UpdateWith` to avoid miss update. (If reference equals, `RemoveAll` breaks impl)