### PR TITLE
Fix invalid JSON deserialization in v0.6.0

### DIFF
--- a/src/PocketBaseClient.CodeGenerator/Generation/ItemInfo.cs
+++ b/src/PocketBaseClient.CodeGenerator/Generation/ItemInfo.cs
@@ -164,8 +164,9 @@ namespace {settings.NamespaceModels}
             : base(id, created, updated)
         {{");
             foreach (var field in Fields)
-                sb.AppendLine($@"            {field.PropertyName} = {GetParameterNameForConstructor(field)};");
+                sb.AppendLine($@"            this.{field.PropertyName} = {GetParameterNameForConstructor(field)};");
             sb.AppendLine($@"
+            AddInternal(this);
         }}
         #endregion");
 

--- a/src/PocketBaseClient/Extensions/PocketBaseExtensions.cs
+++ b/src/PocketBaseClient/Extensions/PocketBaseExtensions.cs
@@ -70,7 +70,7 @@ namespace PocketBaseClient
                     response.EnsureSuccessStatusCode();
 
                     using (var stream = response.Content.ReadAsStream())
-                        return JsonSerializer.Deserialize<T>(stream);
+                        return JsonSerializer.Deserialize<T>(stream, new JsonSerializerOptions(JsonSerializerDefaults.Web));
                 }
                 catch (Exception ex)
                 {

--- a/src/PocketBaseClient/Orm/ItemBase.cs
+++ b/src/PocketBaseClient/Orm/ItemBase.cs
@@ -289,12 +289,13 @@ namespace PocketBaseClient.Orm
         [JsonConstructor]
         public ItemBase(string? id, DateTime? created, DateTime? updated)
         {
-            Id = id;
+            _Id = id;
             Created = created;
             Updated = updated;
+            Metadata_.SetLoaded();
         }
 
-        //protected object? AddInternal(object? element) => Collection.AddInternal(element);
+        protected object? AddInternal(object? element) => Collection.AddInternal(element);
 
         /// <inheritdoc />
         public override string ToString()


### PR DESCRIPTION
This PR includes a fix of two issues.

# The first issue
The first issue is a invalid JSON deserialization of `PocketBaseExtensions.Send<T>`.
In previous version, PocketBaseClient was using pocketbase-csharp-sdk's SendAsync method. But in v0.6.0, it seems like you have migrated from it to PocketBaseExtensions.
PocketBaseExtensions.Send<T> uses System.Text.Json's JSON deserializer, which is case sensitive by default. But pocketbase-csharp-sdk is using [HttpClient's method](https://github.com/PRCV1/pocketbase-csharp-sdk/blob/450445a316971e58aa5632848ade5def1945039a/pocketbase-csharp-sdk/PocketBase.cs#L152) in order to deserialize, so that JSON deserializer uses case-insensitive option.
What we need to add is JSON serialization options of case-insensitive to JSON deserializer.
I used [`JsonSerializerDefaults.Web`](https://learn.microsoft.com/en-us/dotnet/api/system.text.json.jsonserializerdefaults?view=net-6.0) rather than creating our own serializer options. Because pocketbase-csharp-sdk is based on this options according to [this article](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.json.httpcontentjsonextensions.readfromjsonasync?view=net-6.0#:~:text=to%20read%20from.-,options,-JsonSerializerOptions).

# The second issue
I found that my previous PR about invalid json deserialization wasn't fully fixed.
The main cause of it is `AddInternal` is being called before all fields of a item being set.
I'll explain in comments line by line. So please reference to that.