### PR TITLE
Prefix for invalid Enum identifiers (e.g. numbers)

### DIFF
--- a/sdk/pocketbase-csharp-sdk/Services/BaseAuthService.cs
+++ b/sdk/pocketbase-csharp-sdk/Services/BaseAuthService.cs
@@ -6,7 +6,7 @@ namespace pocketbase_csharp_sdk.Services
         where T : AuthModel
     {
         protected readonly PocketBase client;
-        public BaseAuthService(PocketBase client)
+        public BaseAuthService(PocketBase client) : base(client)
         {
             this.client = client;
         }

--- a/sdk/pocketbase-csharp-sdk/Services/BaseCrudService.cs
+++ b/sdk/pocketbase-csharp-sdk/Services/BaseCrudService.cs
@@ -14,7 +14,7 @@ namespace pocketbase_csharp_sdk.Services
     {
         private readonly PocketBase client;
 
-        public BaseCrudService(PocketBase client)
+        public BaseCrudService(PocketBase client) : base(client)
         {
             this.client = client;
         }
@@ -29,23 +29,9 @@ namespace pocketbase_csharp_sdk.Services
         /// <param name="cancellationToken">A cancellation token to cancel the operation. Default is the default cancellation token</param>
         /// <returns>A PagedCollectionModel<T> object containing the paginated list of objects.</returns>
         /// <exception cref="ClientException"></exception>
-        public virtual async Task<PagedCollectionModel<T>> ListAsync(int page = 1, int perPage = 30, string? filter = null, string? sort = null, CancellationToken cancellationToken = default)
+        public virtual Task<PagedCollectionModel<T>> ListAsync(int page = 1, int perPage = 30, string? filter = null, string? sort = null, CancellationToken cancellationToken = default)
         {
-            var query = new Dictionary<string, object?>()
-            {
-                { "filter", filter },
-                { "page", page },
-                { "perPage", perPage },
-                { "sort", sort }
-            };
-
-            var response = await client.SendAsync<PagedCollectionModel<T>>(BasePath(), HttpMethod.Get, query: query, cancellationToken: cancellationToken);
-            if (response is null)
-            {
-                throw new ClientException(BasePath());
-            }
-
-            return response;
+            return base.ListAsync<T>(null, page, perPage, filter, sort, cancellationToken);
         }
 
         /// <summary>
@@ -60,21 +46,7 @@ namespace pocketbase_csharp_sdk.Services
         /// <exception cref="ClientException"></exception>
         public virtual PagedCollectionModel<T> List(int page = 1, int perPage = 30, string? filter = null, string? sort = null, CancellationToken cancellationToken = default)
         {
-            var query = new Dictionary<string, object?>()
-            {
-                { "filter", filter },
-                { "page", page },
-                { "perPage", perPage },
-                { "sort", sort }
-            };
-
-            var response = client.Send<PagedCollectionModel<T>>(BasePath(), HttpMethod.Get, query: query, cancellationToken: cancellationToken);
-            if (response is null)
-            {
-                throw new ClientException(BasePath());
-            }
-
-            return response;
+            return base.List<T>(null, page, perPage, filter, sort, cancellationToken);
         }
 
         /// <summary>
@@ -85,22 +57,9 @@ namespace pocketbase_csharp_sdk.Services
         /// <param name="sort">A sort string to apply to the list. Default is null.</param>
         /// <param name="cancellationToken">A cancellation token to cancel the operation. Default is the default cancellation token.</param>
         /// <returns>An IEnumerable<T> object containing the full list of objects.</returns>
-        public virtual async Task<IEnumerable<T>> GetFullListAsync(int batch = 100, string? filter = null, string? sort = null, CancellationToken cancellationToken = default)
+        public virtual Task<IEnumerable<T>> GetFullListAsync(int batch = 100, string? filter = null, string? sort = null, CancellationToken cancellationToken = default)
         {
-            List<T> result = new();
-            int currentPage = 1;
-            PagedCollectionModel<T> lastResponse;
-            do
-            {
-                lastResponse = await ListAsync(currentPage, perPage: batch, filter: filter, sort: sort, cancellationToken: cancellationToken);
-                if (lastResponse is not null && lastResponse.Items is not null)
-                {
-                    result.AddRange(lastResponse.Items);
-                }
-                currentPage++;
-            } while (lastResponse?.Items?.Length > 0 && lastResponse?.TotalItems > result.Count);
-
-            return result;
+            return base.GetFullListAsync<T>(null, batch, filter, sort, cancellationToken);
         }
 
         /// <summary>
@@ -113,20 +72,7 @@ namespace pocketbase_csharp_sdk.Services
         /// <returns>An IEnumerable<T> object containing the full list of objects.</returns>
         public virtual IEnumerable<T> GetFullList(int batch = 100, string? filter = null, string? sort = null, CancellationToken cancellationToken = default)
         {
-            List<T> result = new();
-            int currentPage = 1;
-            PagedCollectionModel<T> lastResponse;
-            do
-            {
-                lastResponse = List(currentPage, perPage: batch, filter: filter, sort: sort, cancellationToken: cancellationToken);
-                if (lastResponse is not null && lastResponse.Items is not null)
-                {
-                    result.AddRange(lastResponse.Items);
-                }
-                currentPage++;
-            } while (lastResponse?.Items?.Length > 0 && lastResponse?.TotalItems > result.Count);
-
-            return result;
+            return base.GetFullList<T>(null, batch, filter, sort, cancellationToken);
         }
 
     }

--- a/sdk/pocketbase-csharp-sdk/Services/BaseService.cs
+++ b/sdk/pocketbase-csharp-sdk/Services/BaseService.cs
@@ -11,10 +11,12 @@ namespace pocketbase_csharp_sdk.Services
     public abstract class BaseService
     {
         protected readonly string[] itemProperties;
+        private readonly PocketBase pocketBase;
 
-        public BaseService()
+        public BaseService(PocketBase pocketBase)
         {
             this.itemProperties = this.GetPropertyNames().ToArray();
+            this.pocketBase = pocketBase;
         }
 
         protected abstract string BasePath(string? path = null);
@@ -39,12 +41,90 @@ namespace pocketbase_csharp_sdk.Services
         }
 
         private IEnumerable<string> GetPropertyNames()
-            => from prop in typeof(BaseModel).GetProperties()
-               select prop.Name;
+        {
+            return from prop in typeof(BaseModel).GetProperties()
+                   select prop.Name;
+        }
 
         protected string UrlEncode(string param)
         {
             return HttpUtility.UrlEncode(param);
+        }
+
+        internal virtual PagedCollectionModel<T> List<T>(string? sub = null, int page = 1, int perPage = 30, string? filter = null, string? sort = null, CancellationToken cancellationToken = default)
+        {
+            var path = BasePath(sub);
+            var query = new Dictionary<string, object?>()
+            {
+                { "filter", filter },
+                { "page", page },
+                { "perPage", perPage },
+                { "sort", sort }
+            };
+
+            var response = pocketBase.Send<PagedCollectionModel<T>>(path, HttpMethod.Get, query: query, cancellationToken: cancellationToken);
+            if (response is null)
+            {
+                throw new ClientException(BasePath(path));
+            }
+
+            return response;
+        }
+
+        internal virtual async Task<PagedCollectionModel<T>> ListAsync<T>(string? sub = null, int page = 1, int perPage = 30, string? filter = null, string? sort = null, CancellationToken cancellationToken = default)
+        {
+            var path = BasePath(sub);
+            var query = new Dictionary<string, object?>()
+            {
+                { "filter", filter },
+                { "page", page },
+                { "perPage", perPage },
+                { "sort", sort }
+            };
+
+            var response = await pocketBase.SendAsync<PagedCollectionModel<T>>(path, HttpMethod.Get, query: query, cancellationToken: cancellationToken);
+            if (response is null)
+            {
+                throw new ClientException(path);
+            }
+
+            return response;
+        }
+
+        internal virtual IEnumerable<T> GetFullList<T>(string? sub = null, int batch = 100, string? filter = null, string? sort = null, CancellationToken cancellationToken = default)
+        {
+            List<T> result = new();
+            int currentPage = 1;
+            PagedCollectionModel<T> lastResponse;
+            do
+            {
+                lastResponse = List<T>(sub, currentPage, perPage: batch, filter: filter, sort: sort, cancellationToken: cancellationToken);
+                if (lastResponse is not null && lastResponse.Items is not null)
+                {
+                    result.AddRange(lastResponse.Items);
+                }
+                currentPage++;
+            } while (lastResponse?.Items?.Length > 0 && lastResponse?.TotalItems > result.Count);
+
+            return result;
+        }
+
+        internal virtual async Task<IEnumerable<T>> GetFullListAsync<T>(string? sub = null, int batch = 100, string? filter = null, string? sort = null, CancellationToken cancellationToken = default)
+        {
+            List<T> result = new();
+            int currentPage = 1;
+            PagedCollectionModel<T> lastResponse;
+            do
+            {
+                lastResponse = await ListAsync<T>(sub, currentPage, perPage: batch, filter: filter, sort: sort, cancellationToken: cancellationToken);
+                if (lastResponse is not null && lastResponse.Items is not null)
+                {
+                    result.AddRange(lastResponse.Items);
+                }
+                currentPage++;
+            } while (lastResponse?.Items?.Length > 0 && lastResponse?.TotalItems > result.Count);
+
+            return result;
         }
 
     }

--- a/sdk/pocketbase-csharp-sdk/Services/BaseSubCrudService.cs
+++ b/sdk/pocketbase-csharp-sdk/Services/BaseSubCrudService.cs
@@ -18,79 +18,29 @@ namespace pocketbase_csharp_sdk.Services
     {
         private readonly PocketBase client;
 
-        public BaseSubCrudService(PocketBase client)
+        public BaseSubCrudService(PocketBase client) : base(client)
         {
             this.client = client;
         }
 
-        public async Task<PagedCollectionModel<T>> ListAsync<T>(string sub, int? page = null, int? perPage = null, string? sort = null, string? filter = null, string? expand = null, IDictionary<string, string>? headers = null, CancellationToken cancellationToken = default) where T : BaseModel
+        public Task<PagedCollectionModel<T>> ListAsync<T>(string sub, int page = 1, int perPage = 30, string? sort = null, string? filter = null, string? expand = null, IDictionary<string, string>? headers = null, CancellationToken cancellationToken = default) where T : BaseModel
         {
-            var query = new Dictionary<string, object?>()
-            {
-                { "filter", filter },
-                { "page", page },
-                { "perPage", perPage },
-                { "sort", sort },
-                { "expand", expand },
-            };
-            var url = this.BasePath(sub);
-            var pagedResponse = await client.SendAsync<PagedCollectionModel<T>>(url, HttpMethod.Get, headers: headers, query: query, cancellationToken: cancellationToken);
-            if (pagedResponse is null) throw new ClientException(url);
-
-            return pagedResponse;
+            return base.ListAsync<T>(sub, page, perPage, filter, sort, cancellationToken);
         }
 
-        public PagedCollectionModel<T> List<T>(string sub, int? page = null, int? perPage = null, string? sort = null, string? filter = null, string? expand = null, IDictionary<string, string>? headers = null, CancellationToken cancellationToken = default) where T : BaseModel
+        public PagedCollectionModel<T> List<T>(string sub, int page = 1, int perPage = 30, string? sort = null, string? filter = null, string? expand = null, IDictionary<string, string>? headers = null, CancellationToken cancellationToken = default) where T : BaseModel
         {
-            var query = new Dictionary<string, object?>()
-            {
-                { "filter", filter },
-                { "page", page },
-                { "perPage", perPage },
-                { "sort", sort },
-                { "expand", expand },
-            };
-            var url = this.BasePath(sub);
-            var pagedResponse = client.Send<PagedCollectionModel<T>>(url, HttpMethod.Get, headers: headers, query: query, cancellationToken: cancellationToken);
-            if (pagedResponse is null) throw new ClientException(url);
-
-            return pagedResponse;
+            return base.List<T>(sub, page, perPage, filter, sort);
         }
 
-        public async Task<IEnumerable<T>> GetFullListAsync<T>(string sub, int batch = 100, string? filter = null, string? sort = null, CancellationToken cancellationToken = default) where T : BaseModel
+        public Task<IEnumerable<T>> GetFullListAsync<T>(string sub, int batch = 100, string? filter = null, string? sort = null, CancellationToken cancellationToken = default) where T : BaseModel
         {
-            List<T> result = new();
-            int currentPage = 1;
-            PagedCollectionModel<T> lastResponse;
-            do
-            {
-                lastResponse = await ListAsync<T>(sub, page: currentPage, perPage: batch, filter: filter, sort: sort, cancellationToken: cancellationToken);
-                if (lastResponse is not null && lastResponse.Items is not null)
-                {
-                    result.AddRange(lastResponse.Items);
-                }
-                currentPage++;
-            } while (lastResponse?.Items?.Length > 0 && lastResponse?.TotalItems > result.Count);
-
-            return result;
+            return base.GetFullListAsync<T>(sub, batch, filter, sort, cancellationToken);
         }
 
         public IEnumerable<T> GetFullList<T>(string sub, int batch = 100, string? filter = null, string? sort = null, CancellationToken cancellationToken = default) where T : BaseModel
         {
-            List<T> result = new();
-            int currentPage = 1;
-            PagedCollectionModel<T> lastResponse;
-            do
-            {
-                lastResponse = List<T>(sub, page: currentPage, perPage: batch, filter: filter, sort: sort, cancellationToken: cancellationToken);
-                if (lastResponse is not null && lastResponse.Items is not null)
-                {
-                    result.AddRange(lastResponse.Items);
-                }
-                currentPage++;
-            } while (lastResponse?.Items?.Length > 0 && lastResponse?.TotalItems > result.Count);
-
-            return result;
+            return base.GetFullList<T>(sub, batch, filter, sort, cancellationToken);
         }
 
         public async Task<T> CreateAsync<T>(string sub, T item, string? expand = null, IDictionary<string, string>? headers = null, IEnumerable<IFile>? files = null, CancellationToken cancellationToken = default) where T : BaseModel

--- a/sdk/pocketbase-csharp-sdk/Services/HealthService.cs
+++ b/sdk/pocketbase-csharp-sdk/Services/HealthService.cs
@@ -13,7 +13,7 @@ namespace pocketbase_csharp_sdk.Services
 
         protected override string BasePath(string? path = null) => "api/health";
 
-        public HealthService(PocketBase pocketBase)
+        public HealthService(PocketBase pocketBase) : base(pocketBase)
         {
             this.pocketBase = pocketBase;
         }

--- a/sdk/pocketbase-csharp-sdk/Services/LogService.cs
+++ b/sdk/pocketbase-csharp-sdk/Services/LogService.cs
@@ -16,7 +16,7 @@ namespace pocketbase_csharp_sdk.Services
 
         private readonly PocketBase client;
 
-        public LogService(PocketBase client)
+        public LogService(PocketBase client) : base(client)
         {
             this.client = client;
         }

--- a/sdk/pocketbase-csharp-sdk/Services/RealTimeService.cs
+++ b/sdk/pocketbase-csharp-sdk/Services/RealTimeService.cs
@@ -14,7 +14,7 @@ namespace pocketbase_csharp_sdk.Services
 
         private readonly Dictionary<string, List<Func<SseMessage, Task>>> Subscriptions = new();
 
-        public RealTimeService(PocketBase client)
+        public RealTimeService(PocketBase client) : base(client)
         {
             this.client = client;
         }

--- a/sdk/pocketbase-csharp-sdk/Services/SettingsService.cs
+++ b/sdk/pocketbase-csharp-sdk/Services/SettingsService.cs
@@ -14,7 +14,7 @@ namespace pocketbase_csharp_sdk.Services
 
         private readonly PocketBase client;
 
-        public SettingsService(PocketBase client)
+        public SettingsService(PocketBase client) : base(client)
         {
             this.client = client;
         }

--- a/sdk/pocketbase-csharp-sdk/Services/UserService.cs
+++ b/sdk/pocketbase-csharp-sdk/Services/UserService.cs
@@ -89,24 +89,25 @@ namespace pocketbase_csharp_sdk.Services
         /// <param name="cancellationToken">The cancellation token for the request.</param>
         /// <returns>A task that returns a `PagedCollectionModel` of `UserModel`.</returns>
         /// <exception cref="ClientException">Thrown if the client fails to send the request or receive a response.</exception>
-        public override async Task<PagedCollectionModel<UserModel>> ListAsync(int page = 1, int perPage = 30, string? filter = null, string? sort = null, CancellationToken cancellationToken = default)
+        public Task<PagedCollectionModel<UserModel>> ListAsync(int page = 1, int perPage = 30, string? filter = null, string? sort = null, CancellationToken cancellationToken = default)
         {
-            var query = new Dictionary<string, object?>()
-            {
-                { "filter", filter },
-                { "page", page },
-                { "perPage", perPage },
-                { "sort", sort }
-            };
+            return base.ListAsync<UserModel>();
+            //var query = new Dictionary<string, object?>()
+            //{
+            //    { "filter", filter },
+            //    { "page", page },
+            //    { "perPage", perPage },
+            //    { "sort", sort }
+            //};
 
-            var url = $"{BasePath()}/records";
-            var response = await client.SendAsync<PagedCollectionModel<UserModel>>(url, HttpMethod.Get, query: query, cancellationToken: cancellationToken);
-            if (response is null)
-            {
-                throw new ClientException(BasePath());
-            }
+            //var url = $"{BasePath()}/records";
+            //var response = await client.SendAsync<PagedCollectionModel<UserModel>>(url, HttpMethod.Get, query: query, cancellationToken: cancellationToken);
+            //if (response is null)
+            //{
+            //    throw new ClientException(BasePath());
+            //}
 
-            return response;
+            //return response;
         }
 
         /// <summary>
@@ -149,22 +150,9 @@ namespace pocketbase_csharp_sdk.Services
         /// <param name="cancellationToken">The cancellation token for the request.</param>
         /// <returns>A task that returns a `PagedCollectionModel` of `UserModel`.</returns>
         /// <exception cref="ClientException">Thrown if the client fails to send the request or receive a response.</exception>
-        public override async Task<IEnumerable<UserModel>> GetFullListAsync(int batch = 100, string? filter = null, string? sort = null, CancellationToken cancellationToken = default)
+        public Task<IEnumerable<UserModel>> GetFullListAsync(int batch = 100, string? filter = null, string? sort = null, CancellationToken cancellationToken = default)
         {
-            List<UserModel> result = new();
-            int currentPage = 1;
-            PagedCollectionModel<UserModel> lastResponse;
-            do
-            {
-                lastResponse = await ListAsync(currentPage, perPage: batch, filter: filter, sort: sort, cancellationToken: cancellationToken);
-                if (lastResponse is not null && lastResponse.Items is not null)
-                {
-                    result.AddRange(lastResponse.Items);
-                }
-                currentPage++;
-            } while (lastResponse?.Items?.Length > 0 && lastResponse?.TotalItems > result.Count);
-
-            return result;
+            return base.GetFullListAsync<UserModel>(null, batch, filter, sort, cancellationToken);
         }
 
         /// <summary>
@@ -179,20 +167,7 @@ namespace pocketbase_csharp_sdk.Services
         /// <exception cref="ClientException">Thrown if the client fails to send the request or receive a response.</exception>
         public override IEnumerable<UserModel> GetFullList(int batch = 100, string? filter = null, string? sort = null, CancellationToken cancellationToken = default)
         {
-            List<UserModel> result = new();
-            int currentPage = 1;
-            PagedCollectionModel<UserModel> lastResponse;
-            do
-            {
-                lastResponse = List(currentPage, perPage: batch, filter: filter, sort: sort, cancellationToken: cancellationToken);
-                if (lastResponse is not null && lastResponse.Items is not null)
-                {
-                    result.AddRange(lastResponse.Items);
-                }
-                currentPage++;
-            } while (lastResponse?.Items?.Length > 0 && lastResponse?.TotalItems > result.Count);
-
-            return result;
+            return base.GetFullList<UserModel>(null, batch, filter, sort, cancellationToken);
         }
 
         /// <summary>

--- a/src/PocketBaseClient.CodeGenerator/Generation/FieldInfoSelect.cs
+++ b/src/PocketBaseClient.CodeGenerator/Generation/FieldInfoSelect.cs
@@ -12,6 +12,7 @@ using pocketbase_csharp_sdk.Models.Collection;
 using PocketBaseClient.CodeGenerator.Models;
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 
 namespace PocketBaseClient.CodeGenerator.Generation
 {
@@ -79,7 +80,14 @@ namespace {settings.NamespaceModels}
             foreach (var value in Options.Values ?? new List<string>())
             {
                 sb.AppendLine(@$"{indent}[Description(""{value}"")]");
-                sb.AppendLine(@$"{indent}{value.ToPascalCase()},");
+                // Rough check if the value is a valid C# identifier
+                // If the value is not a valid C# identifier, prefix it with E
+                // https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#643-identifiers
+                if (Regex.IsMatch(value, @"^[\p{L}\p{Nl}_]"))
+                    sb.AppendLine(@$"{indent}{value.ToPascalCase()},");
+                else
+                    sb.AppendLine(@$"{indent}E{value.ToPascalCase()},");
+                   
                 sb.AppendLine();
             }
             sb.Append($@"


### PR DESCRIPTION
Just added a quick regex check before generating Select/Enum values for identifying invalid starting characters based on the language specification.

For example a Select with the values `1, 2`

would output:
```
public enum ExampleEnum
{
    [Description("1")]
    1,

    [Description("2")]
    2,
}
```

This change would prefix them with 'E' like [pocketbase-typegen](https://github.com/patmood/pocketbase-typegen/pull/75) does.

```
public enum ShiftEnum
{
    [Description("1")]
    E2,

    [Description("2")]
    E2,
}
```